### PR TITLE
Add nginx reverse proxy for TLS termination

### DIFF
--- a/lib/restate-constructs/register-service-handler/index.ts
+++ b/lib/restate-constructs/register-service-handler/index.ts
@@ -14,6 +14,7 @@ import { CloudFormationCustomResourceEvent } from "aws-lambda/trigger/cloudforma
 import fetch from "node-fetch";
 import * as cdk from "aws-cdk-lib";
 import { GetSecretValueCommand, SecretsManagerClient } from "@aws-sdk/client-secrets-manager";
+import * as https from "https";
 
 export interface RegistrationProperties {
   servicePath?: string;
@@ -32,6 +33,8 @@ type EndpointResponse = {
 
 const MAX_HEALTH_CHECK_ATTEMPTS = 4;
 const MAX_REGISTRATION_ATTEMPTS = 3;
+
+const INSECURE = true;
 
 /**
  * Custom Resource event handler for Restate service registration. This handler backs the custom resources created by
@@ -55,6 +58,7 @@ export const handler: Handler<CloudFormationCustomResourceEvent, void> = async f
     //   const deleteResponse = await fetch(`${props.metaEndpoint}/endpoints/${id}?force=true`, {
     //     signal: controller.signal,
     //     method: "DELETE",
+    //     agent: INSECURE ? new https.Agent({ rejectUnauthorized: false }) : undefined,
     //   }).finally(() => clearTimeout(deleteCallTimeout));
     //
     //   console.log(`Got delete response back: ${deleteResponse.status}`);
@@ -85,6 +89,7 @@ export const handler: Handler<CloudFormationCustomResourceEvent, void> = async f
       healthResponse = await fetch(healthCheckUrl, {
         signal: controller.signal,
         headers: authHeader,
+        agent: INSECURE ? new https.Agent({ rejectUnauthorized: false }) : undefined,
       }).finally(() => clearTimeout(healthCheckTimeout));
 
       console.log(`Got health check response back: ${healthResponse.status}`);
@@ -129,6 +134,7 @@ export const handler: Handler<CloudFormationCustomResourceEvent, void> = async f
           "Content-Type": "application/json",
           ...authHeader,
         },
+        agent: INSECURE ? new https.Agent({ rejectUnauthorized: false }) : undefined,
       }).finally(() => clearTimeout(registerCallTimeout));
 
       console.log(`Got registration response back: ${discoveryResponse.status}`);


### PR DESCRIPTION
This change restores HTTPS support for the single-node Restate construct by deploying an nginx reverse proxy configured with ingress and meta listeners, using a self-signed certificate, directly on the EC2 host.

```
❯ npx cdk deploy [...]

 ✅  pt-ec2-RestateStack

✨  Deployment time: 31.92s

Outputs:
pt-ec2-RestateStack.ExportsOutputFnGetAttRestateHost1AC4F9D1PublicDnsName90BD9412 = ec2-18-184-110-108.eu-central-1.compute.amazonaws.com
pt-ec2-RestateStack.ExportsOutputFnGetAttRestateInstanceRoleACC59A6FArn348D1AD6 = arn:aws:iam::663487780041:role/pt-ec2-RestateStack-RestateInstanceRoleACC59A6F-hmXxXALe41D7
pt-ec2-RestateStack.ExportsOutputFnGetAttRestateRegistrationProviderframeworkonEventC2D8D44FArnB7A27897 = arn:aws:lambda:eu-central-1:663487780041:function:pt-ec2-RestateStack-RestateRegistrationProviderfra-BKwi82TzwGCS
pt-ec2-RestateStack.RestateHostInstanceId = i-0346e00e2c431e4af
pt-ec2-RestateStack.RestateIngressEndpoint = https://ec2-18-184-110-108.eu-central-1.compute.amazonaws.com
pt-ec2-RestateStack.RestateMetaEndpoint = https://ec2-18-184-110-108.eu-central-1.compute.amazonaws.com:9073
pt-ec2-RestateStack.RestateRegistrationProviderToken6ED9A8E4 = arn:aws:lambda:eu-central-1:663487780041:function:pt-ec2-RestateStack-RestateRegistrationProviderfra-BKwi82TzwGCS
Stack ARN:
arn:aws:cloudformation:eu-central-1:663487780041:stack/pt-ec2-RestateStack/6e077b90-92c9-11ee-a325-028511a2d5e7

❯ curl -kv $INGRESS/trips/reserve --json '{}'
*   Trying 18.184.110.108:443...
* Connected to ec2-18-184-110-108.eu-central-1.compute.amazonaws.com (18.184.110.108) port 443 (#0)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
* (304) (IN), TLS handshake, Server hello (2):
* (304) (IN), TLS handshake, Unknown (8):
* (304) (IN), TLS handshake, Certificate (11):
* (304) (IN), TLS handshake, CERT verify (15):
* (304) (IN), TLS handshake, Finished (20):
* (304) (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384
* ALPN: server accepted h2
* Server certificate:
*  subject: C=DE; ST=Berlin; L=Berlin; O=restate.dev; OU=demo; CN=restate.example.com
*  start date: Dec  4 17:24:08 2023 GMT
*  expire date: Dec  3 17:24:08 2024 GMT
*  issuer: C=DE; ST=Berlin; L=Berlin; O=restate.dev; OU=demo; CN=restate.example.com
*  SSL certificate verify result: self signed certificate (18), continuing anyway.
* using HTTP/2
* h2 [:method: POST]
* h2 [:scheme: https]
* h2 [:authority: ec2-18-184-110-108.eu-central-1.compute.amazonaws.com]
* h2 [:path: /trips/reserve]
* h2 [user-agent: curl/8.1.2]
* h2 [content-type: application/json]
* h2 [accept: application/json]
* h2 [content-length: 2]
* Using Stream ID: 1 (easy handle 0x13100c200)
> POST /trips/reserve HTTP/2
> Host: ec2-18-184-110-108.eu-central-1.compute.amazonaws.com
> User-Agent: curl/8.1.2
> Content-Type: application/json
> Accept: application/json
> Content-Length: 2
>
* We are completely uploaded and fine
< HTTP/2 200
< server: nginx/1.24.0
< date: Mon, 04 Dec 2023 18:01:30 GMT
< content-type: application/json
< content-length: 82
< access-control-allow-credentials: true
< vary: origin
< vary: access-control-request-method
< vary: access-control-request-headers
<
* Connection #0 to host ec2-18-184-110-108.eu-central-1.compute.amazonaws.com left intact
{"response":{"status":"success","trip_id":"325d04de-9adc-4f32-b8c8-d047352e22c4"}}
```