### PR TITLE
Expand README, link to documentation reference page

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # Restate CDK support
 
 AWS Cloud Development Kit (CDK) construct library for deploying [Restate](https://restate.dev) and Restate services on
-AWS. This library helps you when deploying Restate services to AWS Lambda as well as for managing a self-hosted Restate
+AWS. This library helps you when deploying Restate services to AWS Lambda as well as for managing self-hosted Restate
 deployments on your own infrastructure. For more information on CDK, please
 see [Getting started with the AWS CDK](https://docs.aws.amazon.com/cdk/v2/guide/getting_started.html).
 

--- a/README.md
+++ b/README.md
@@ -4,4 +4,27 @@
 
 # Restate CDK support
 
-CDK construct library for deploying [Restate](https://restate.dev) and Restate services on AWS.
+AWS Cloud Development Kit (CDK) construct library for deploying [Restate](https://restate.dev) and Restate services on
+AWS. This library helps you when deploying Restate services to AWS Lambda as well as for managing a self-hosted Restate
+deployments on your own infrastructure. For more information on CDK, please
+see [Getting started with the AWS CDK](https://docs.aws.amazon.com/cdk/v2/guide/getting_started.html).
+
+## Available constructs
+
+- [`LambdaServiceRegistry`](./lib/restate-constructs/lambda-service-registry.ts) - A collection of Lambda-deployed
+  Restate services, this construct automatically registers the latest function version as a new deployment revision in a
+  Restate instance
+- [`SingleNodeRestateInstance`](./lib/restate-constructs/single-node-restate-instance.ts) - Deploys a self-hosted
+  Restate instance on EC2; note this is a single-node deployment targeted at development and testing
+- [`RestateCloudEndpoint`](./lib/restate-constructs/restate-cloud-endpoint.ts) - A Restate Cloud instance
+
+For a more detailed overview, please see the [Restate CDK documentation](https://docs.restate.dev/services/deployment/cdk).
+
+### Examples
+
+You can use the following examples as references for your own CDK projects:
+
+- [hello-world-lambda-cdk](https://github.com/restatedev/examples/tree/main/kotlin/hello-world-lambda-cdk) - provides a
+  simple example of a Lambda-deployed Kotlin handler
+- [Restate Holiday](https://github.com/restatedev/restate-holiday) - a more complex example of a fictional reservation
+  service demonstrating the Saga orchestration pattern


### PR DESCRIPTION
- add brief overview of included constructs and their purpose
- link to main CDK overview page in Restate docs (to be introduced in https://github.com/restatedev/documentation/pull/234)
- links to CDK example code elsewhere