### PR TITLE
Update CDK constructs for Restate 0.7.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ see [Getting started with the AWS CDK](https://docs.aws.amazon.com/cdk/v2/guide/
 - [`LambdaServiceRegistry`](./lib/restate-constructs/lambda-service-registry.ts) - A collection of Lambda-deployed
   Restate services, this construct automatically registers the latest function version as a new deployment revision in a
   Restate instance
-- [`SingleNodeRestateInstance`](./lib/restate-constructs/single-node-restate-instance.ts) - Deploys a self-hosted
+- [`SingleNodeRestateInstance`](./lib/restate-constructs/single-node-restate-deployment.ts) - Deploys a self-hosted
   Restate instance on EC2; note this is a single-node deployment targeted at development and testing
-- [`RestateCloudEndpoint`](./lib/restate-constructs/restate-cloud-endpoint.ts) - A Restate Cloud instance
+- [`RestateCloudEndpoint`](./lib/restate-constructs/restate-cloud-environment.ts) - A Restate Cloud instance
 
 For a more detailed overview, please see the [Restate CDK documentation](https://docs.restate.dev/services/deployment/cdk).
 

--- a/README.md
+++ b/README.md
@@ -15,17 +15,18 @@ see [Getting started with the AWS CDK](https://docs.aws.amazon.com/cdk/v2/guide/
 - [`LambdaServiceRegistry`](./lib/restate-constructs/lambda-service-registry.ts) - A collection of Lambda-deployed
   Restate services, this construct automatically registers the latest function version as a new deployment revision in a
   Restate instance
-- [`SingleNodeRestateInstance`](./lib/restate-constructs/single-node-restate-deployment.ts) - Deploys a self-hosted
+- [`SingleNodeRestateDeployment`](./lib/restate-constructs/single-node-restate-deployment.ts) - Deploys a self-hosted
   Restate instance on EC2; note this is a single-node deployment targeted at development and testing
-- [`RestateCloudEndpoint`](./lib/restate-constructs/restate-cloud-environment.ts) - A Restate Cloud instance
+- [`RestateCloudEnvironment`](./lib/restate-constructs/restate-cloud-environment.ts) - A Restate Cloud instance
 
-For a more detailed overview, please see the [Restate CDK documentation](https://docs.restate.dev/services/deployment/cdk).
+For a more detailed overview, please see
+the [Restate CDK documentation](https://docs.restate.dev/services/deployment/cdk).
 
 ### Examples
 
 You can use the following examples as references for your own CDK projects:
 
-- [hello-world-lambda-cdk](https://github.com/restatedev/examples/tree/main/kotlin/hello-world-lambda-cdk) - provides a
-  simple example of a Lambda-deployed Kotlin handler
+- [hello-world-lambda-cdk](https://github.com/restatedev/examples/tree/main/kotlin/hello-world-lambda-cdk) - Kotlin
+  service deployed to AWS Lambda
 - [Restate Holiday](https://github.com/restatedev/restate-holiday) - a more complex example of a fictional reservation
   service demonstrating the Saga orchestration pattern

--- a/lib/restate-constructs/index.ts
+++ b/lib/restate-constructs/index.ts
@@ -11,6 +11,6 @@
 
 export * from "./lambda-service-registry";
 export * from "./registration-provider";
-export * from "./restate-cloud-endpoint";
-export * from "./restate-instance";
-export * from "./single-node-restate-instance";
+export * from "./restate-cloud-environment";
+export * from "./restate-environment";
+export * from "./single-node-restate-deployment";

--- a/lib/restate-constructs/lambda-service-registry.ts
+++ b/lib/restate-constructs/lambda-service-registry.ts
@@ -15,7 +15,7 @@ import * as lambda from "aws-cdk-lib/aws-lambda";
 import { Construct } from "constructs";
 import { RegistrationProperties } from "./register-service-handler";
 
-import { RestateInstance } from "./restate-instance";
+import { RestateEnvironment } from "./restate-environment";
 
 /**
  * A Restate RPC service path. Example: `greeter`.
@@ -23,7 +23,7 @@ import { RestateInstance } from "./restate-instance";
 type RestatePath = string;
 
 export interface RestateInstanceRef {
-  readonly metaEndpoint: string;
+  readonly adminUrl: string;
   readonly invokerRoleArn: string;
   readonly authTokenSecretArn?: string;
 }
@@ -40,7 +40,7 @@ export type LambdaServiceRegistryProps = {
   /**
    * Custom resource provider token required for service discovery.
    */
-  restate: RestateInstance;
+  restate: RestateEnvironment;
 }
 
 /**
@@ -118,7 +118,7 @@ class RestateServiceRegistrar extends Construct {
       resourceType: "Custom::RestateServiceRegistrar",
       properties: {
         servicePath: props.service.path,
-        metaEndpoint: props.restate.metaEndpoint,
+        adminUrl: props.restate.adminUrl,
         authTokenSecretArn: props.restate.authTokenSecretArn,
         serviceLambdaArn: props.service.handler.currentVersion.functionArn,
         invokeRoleArn: props.restate.invokerRoleArn,

--- a/lib/restate-constructs/lambda-service-registry.ts
+++ b/lib/restate-constructs/lambda-service-registry.ts
@@ -42,7 +42,7 @@ export type LambdaServiceRegistryProps = {
  * construct creates a custom resource which will trigger Restate service discovery on handler function changes.
  */
 export class LambdaServiceRegistry extends Construct {
-  private readonly registrationProviderToken: string;
+  private readonly registrationProviderToken: cdk.CfnOutput;
   private readonly serviceHandlers: Record<RestatePath, lambda.Function>;
 
   constructor(scope: Construct, id: string, props: LambdaServiceRegistryProps) {
@@ -53,7 +53,7 @@ export class LambdaServiceRegistry extends Construct {
     }
 
     this.serviceHandlers = props.handlers;
-    this.registrationProviderToken = props.environment.registrationProviderToken.value;
+    this.registrationProviderToken = props.environment.registrationProviderToken;
     this.registerServices(props.environment);
   }
 
@@ -89,7 +89,7 @@ export class LambdaServiceRegistry extends Construct {
     const registrar = new RestateServiceRegistrar(this, service.handler.node.id + "Discovery", {
       environment: restate,
       service,
-      serviceToken: this.registrationProviderToken,
+      serviceToken: this.registrationProviderToken.value,
     });
 
     // CloudFormation doesn't know that Restate depends on this role to call services; we must ensure that Lambda

--- a/lib/restate-constructs/register-service-handler/index.ts
+++ b/lib/restate-constructs/register-service-handler/index.ts
@@ -30,7 +30,7 @@ type RegisterDeploymentResponse = {
   services?: { name?: string; revision?: number }[];
 };
 
-const MAX_HEALTH_CHECK_ATTEMPTS = 3;
+const MAX_HEALTH_CHECK_ATTEMPTS = 5; // This is intentionally quite long to allow some time for first-run EC2 and Docker boot up
 const MAX_REGISTRATION_ATTEMPTS = 3;
 
 const INSECURE = true;
@@ -111,7 +111,7 @@ export const handler: Handler<CloudFormationCustomResourceEvent, void> = async f
     }
     attempt += 1;
 
-    const waitTimeMillis = 2 ** attempt * 1_000;
+    const waitTimeMillis = 2_000 + 2 ** attempt * 1_000; // 3s -> 6s -> 10s -> 18s -> 34s
     console.log(`Retrying after ${waitTimeMillis} ms...`);
     await sleep(waitTimeMillis);
   }

--- a/lib/restate-constructs/register-service-handler/index.ts
+++ b/lib/restate-constructs/register-service-handler/index.ts
@@ -35,13 +35,13 @@ const MAX_REGISTRATION_ATTEMPTS = 3;
 
 const INSECURE = true;
 
-const DEPLOYMENTS_PATH = "endpoints" // TODO: update to "deployments" for 0.7.0
+const DEPLOYMENTS_PATH = "deployments";
 
 /**
  * Custom Resource event handler for Restate service registration. This handler backs the custom resources created by
  * {@link LambdaServiceRegistry} to facilitate Lambda service handler discovery.
  */
-export const handler: Handler<CloudFormationCustomResourceEvent, void> = async function (event) {
+export const handler: Handler<CloudFormationCustomResourceEvent, void> = async function(event) {
   console.log({ event });
 
   if (event.RequestType === "Delete") {

--- a/lib/restate-constructs/registration-provider.ts
+++ b/lib/restate-constructs/registration-provider.ts
@@ -18,7 +18,7 @@ import * as cdk from "aws-cdk-lib";
 import * as cr from "aws-cdk-lib/custom-resources";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
 
-const DEFAULT_TIMEOUT = cdk.Duration.seconds(120);
+const DEFAULT_TIMEOUT = cdk.Duration.seconds(180);
 
 export class RegistrationProvider extends Construct {
   readonly serviceToken: string;

--- a/lib/restate-constructs/restate-environment.ts
+++ b/lib/restate-constructs/restate-environment.ts
@@ -3,12 +3,12 @@ import * as cdk from "aws-cdk-lib";
 import * as ssm from "aws-cdk-lib/aws-secretsmanager";
 
 /**
- * Represents an instance of the Restate service. This could represent a self-hosted broker, or Restate's managed
- * service.
+ * A Restate environment is a distinct deployment target. These could be an isolated environment in Restate Cloud, or
+ * a self-hosted deployment.
  */
-export interface RestateInstance {
+export interface RestateEnvironment {
   readonly invokerRole: iam.IRole;
-  readonly metaEndpoint: string;
+  readonly adminUrl: string;
   readonly authToken?: ssm.ISecret;
   readonly registrationProviderToken: cdk.CfnOutput;
 }

--- a/lib/restate-constructs/single-node-restate-deployment.ts
+++ b/lib/restate-constructs/single-node-restate-deployment.ts
@@ -21,6 +21,7 @@ const PUBLIC_INGRESS_PORT = 443;
 const PUBLIC_ADMIN_PORT = 9073;
 const RESTATE_INGRESS_PORT = 8080;
 const RESTATE_ADMIN_PORT = 9070;
+const RESTATE_IMAGE_DEFAULT = "docker.io/restatedev/restate";
 const RESTATE_DOCKER_DEFAULT_TAG = "latest";
 const ADOT_DOCKER_DEFAULT_TAG = "latest";
 
@@ -38,6 +39,9 @@ export interface RestateInstanceProps {
 
   /** Prefix for resources created by this construct that require unique names. */
   prefix?: string;
+
+  /** Restate Docker image name. Defaults to `latest`. */
+  restateImage?: string;
 
   /** Restate Docker image tag. Defaults to `latest`. */
   restateTag?: string;
@@ -76,6 +80,7 @@ export class SingleNodeRestateDeployment extends Construct implements RestateEnv
     });
     props.logGroup.grantWrite(this.invokerRole);
 
+    const restateImage = props.restateImage ?? RESTATE_IMAGE_DEFAULT;
     const restateTag = props.restateTag ?? RESTATE_DOCKER_DEFAULT_TAG;
     const adotTag = props.adotTag ?? ADOT_DOCKER_DEFAULT_TAG;
     const restateInitCommands = ec2.UserData.forLinux();
@@ -96,7 +101,7 @@ export class SingleNodeRestateDeployment extends Construct implements RestateEnv
         " -e RESTATE_OBSERVABILITY__LOG__FORMAT=Json -e RUST_LOG=info,restate_worker::partition=warn",
         " -e RESTATE_OBSERVABILITY__TRACING__ENDPOINT=http://localhost:4317",
         ` --log-driver=awslogs --log-opt awslogs-group=${props.logGroup.logGroupName}`,
-        ` docker.io/restatedev/restate:${restateTag}`,
+        ` ${restateImage}:${restateTag}`,
       ].join(""),
 
       "mkdir -p /etc/pki/private",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@types/jest": "^29.5.11",
         "@types/node": "^20.11.0",
         "@types/source-map-support": "^0.5.10",
-        "aws-cdk": "^2.119.0",
+        "aws-cdk": "^2.120.0",
         "esbuild": "^0.19.11",
         "jest": "^29.7.0",
         "prettier": "^3.1.1",
@@ -23,7 +23,7 @@
       },
       "peerDependencies": {
         "@aws-sdk/client-secrets-manager": "^3.462.0",
-        "aws-cdk-lib": "^2.113.0",
+        "aws-cdk-lib": "^2.120.0",
         "constructs": "^10.0.0",
         "node-fetch": "^3.3.2",
         "source-map-support": "^0.5.21"
@@ -2856,9 +2856,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.119.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.119.0.tgz",
-      "integrity": "sha512-5+cCX2TzZLiistzFMKxcWQEc0MRkE+48sOkWdfN/8qJ5jnmZs4RpWTVU1HtkQKwEbBsz9jACpRFpkbu7S2Uitg==",
+      "version": "2.120.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.120.0.tgz",
+      "integrity": "sha512-1kAxwMELEaFTIYIhB69DhaqBydujAPrQvZjngWQeV9Nt+AsiWzwmtGncql7u0oroyDrJEjdneGgqp2HjIiL1ZQ==",
       "dev": true,
       "bin": {
         "cdk": "bin/cdk"
@@ -2871,9 +2871,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.119.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.119.0.tgz",
-      "integrity": "sha512-aq1CFM4KkgJ0tkXCvkeCd2ThFxbaJCY5GVzG5X9SajSKEng7i4mmtblTRLfkz2lwhJLcoHXrvD0Nmf8kcNP5fg==",
+      "version": "2.120.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.120.0.tgz",
+      "integrity": "sha512-EOcbN4I33NS+1z8YnOfUQ7QzuSj4Hjr3p/PTwsQH962fE/EEGyeHAGCL8TLEQMZfFfKVnvPwi3eD5TJXooOU7w==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,25 +1,25 @@
 {
   "name": "@restatedev/restate-cdk",
-  "version": "0.4.2",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@restatedev/restate-cdk",
-      "version": "0.4.2",
+      "version": "0.7.0",
       "license": "MIT",
       "devDependencies": {
-        "@types/aws-lambda": "^8.10.126",
-        "@types/jest": "^29.5.8",
-        "@types/node": "20.9.0",
+        "@types/aws-lambda": "^8.10.131",
+        "@types/jest": "^29.5.11",
+        "@types/node": "^20.11.0",
         "@types/source-map-support": "^0.5.10",
-        "aws-cdk": "2.108.0",
-        "esbuild": "^0.19.6",
+        "aws-cdk": "^2.119.0",
+        "esbuild": "^0.19.11",
         "jest": "^29.7.0",
-        "prettier": "^3.1.0",
+        "prettier": "^3.1.1",
         "ts-jest": "^29.1.1",
-        "ts-node": "^10.9.1",
-        "typescript": "~5.2.2"
+        "ts-node": "^10.9.2",
+        "typescript": "^5.3.3"
       },
       "peerDependencies": {
         "@aws-sdk/client-secrets-manager": "^3.462.0",
@@ -164,49 +164,49 @@
       "peer": true
     },
     "node_modules/@aws-sdk/client-secrets-manager": {
-      "version": "3.484.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.484.0.tgz",
-      "integrity": "sha512-ZBKJYiV6KnlDI2+WG6fJGXHIsP5nINRB4IrKF6sr+svv7CRrBOuDgAWYvqWOjt3fVe2DC7RM/B9/Huu45o9reA==",
+      "version": "3.490.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.490.0.tgz",
+      "integrity": "sha512-wd+PBIMOfSY9CpHfAAE9ztwwde7wom3/VdSqLbBUAUAvAlArANmBS610iCZSFP3ds38v8rnliAV9fjzf7IVnxQ==",
       "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.484.0",
-        "@aws-sdk/core": "3.481.0",
-        "@aws-sdk/credential-provider-node": "3.484.0",
-        "@aws-sdk/middleware-host-header": "3.468.0",
-        "@aws-sdk/middleware-logger": "3.468.0",
-        "@aws-sdk/middleware-recursion-detection": "3.468.0",
-        "@aws-sdk/middleware-signing": "3.468.0",
-        "@aws-sdk/middleware-user-agent": "3.478.0",
-        "@aws-sdk/region-config-resolver": "3.484.0",
-        "@aws-sdk/types": "3.468.0",
-        "@aws-sdk/util-endpoints": "3.478.0",
-        "@aws-sdk/util-user-agent-browser": "3.468.0",
-        "@aws-sdk/util-user-agent-node": "3.470.0",
-        "@smithy/config-resolver": "^2.0.22",
-        "@smithy/core": "^1.2.1",
-        "@smithy/fetch-http-handler": "^2.3.1",
-        "@smithy/hash-node": "^2.0.17",
-        "@smithy/invalid-dependency": "^2.0.15",
-        "@smithy/middleware-content-length": "^2.0.17",
-        "@smithy/middleware-endpoint": "^2.2.3",
-        "@smithy/middleware-retry": "^2.0.25",
-        "@smithy/middleware-serde": "^2.0.15",
-        "@smithy/middleware-stack": "^2.0.9",
-        "@smithy/node-config-provider": "^2.1.8",
-        "@smithy/node-http-handler": "^2.2.1",
-        "@smithy/protocol-http": "^3.0.11",
-        "@smithy/smithy-client": "^2.2.0",
-        "@smithy/types": "^2.7.0",
-        "@smithy/url-parser": "^2.0.15",
+        "@aws-sdk/client-sts": "3.490.0",
+        "@aws-sdk/core": "3.490.0",
+        "@aws-sdk/credential-provider-node": "3.490.0",
+        "@aws-sdk/middleware-host-header": "3.489.0",
+        "@aws-sdk/middleware-logger": "3.489.0",
+        "@aws-sdk/middleware-recursion-detection": "3.489.0",
+        "@aws-sdk/middleware-signing": "3.489.0",
+        "@aws-sdk/middleware-user-agent": "3.489.0",
+        "@aws-sdk/region-config-resolver": "3.489.0",
+        "@aws-sdk/types": "3.489.0",
+        "@aws-sdk/util-endpoints": "3.489.0",
+        "@aws-sdk/util-user-agent-browser": "3.489.0",
+        "@aws-sdk/util-user-agent-node": "3.489.0",
+        "@smithy/config-resolver": "^2.0.23",
+        "@smithy/core": "^1.2.2",
+        "@smithy/fetch-http-handler": "^2.3.2",
+        "@smithy/hash-node": "^2.0.18",
+        "@smithy/invalid-dependency": "^2.0.16",
+        "@smithy/middleware-content-length": "^2.0.18",
+        "@smithy/middleware-endpoint": "^2.3.0",
+        "@smithy/middleware-retry": "^2.0.26",
+        "@smithy/middleware-serde": "^2.0.16",
+        "@smithy/middleware-stack": "^2.0.10",
+        "@smithy/node-config-provider": "^2.1.9",
+        "@smithy/node-http-handler": "^2.2.2",
+        "@smithy/protocol-http": "^3.0.12",
+        "@smithy/smithy-client": "^2.2.1",
+        "@smithy/types": "^2.8.0",
+        "@smithy/url-parser": "^2.0.16",
         "@smithy/util-base64": "^2.0.1",
         "@smithy/util-body-length-browser": "^2.0.1",
         "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.23",
-        "@smithy/util-defaults-mode-node": "^2.0.31",
-        "@smithy/util-endpoints": "^1.0.7",
-        "@smithy/util-retry": "^2.0.8",
+        "@smithy/util-defaults-mode-browser": "^2.0.24",
+        "@smithy/util-defaults-mode-node": "^2.0.32",
+        "@smithy/util-endpoints": "^1.0.8",
+        "@smithy/util-retry": "^2.0.9",
         "@smithy/util-utf8": "^2.0.2",
         "tslib": "^2.5.0",
         "uuid": "^8.3.2"
@@ -216,46 +216,46 @@
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.484.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.484.0.tgz",
-      "integrity": "sha512-eHKXDHqgPt99977hNissa1y/efwXZ9kg3EKPLK13b6VzTC8s0+Ih+YZemNE22ahw6SYnRiGglYdkdypJ/uPHkg==",
+      "version": "3.490.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.490.0.tgz",
+      "integrity": "sha512-yfxoHmCL1w/IKmFRfzCxdVCQrGlSQf4eei9iVEm5oi3iE8REFyPj3o/BmKQEHG3h2ITK5UbdYDb5TY4xoYHsyA==",
       "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/core": "3.481.0",
-        "@aws-sdk/middleware-host-header": "3.468.0",
-        "@aws-sdk/middleware-logger": "3.468.0",
-        "@aws-sdk/middleware-recursion-detection": "3.468.0",
-        "@aws-sdk/middleware-user-agent": "3.478.0",
-        "@aws-sdk/region-config-resolver": "3.484.0",
-        "@aws-sdk/types": "3.468.0",
-        "@aws-sdk/util-endpoints": "3.478.0",
-        "@aws-sdk/util-user-agent-browser": "3.468.0",
-        "@aws-sdk/util-user-agent-node": "3.470.0",
-        "@smithy/config-resolver": "^2.0.22",
-        "@smithy/core": "^1.2.1",
-        "@smithy/fetch-http-handler": "^2.3.1",
-        "@smithy/hash-node": "^2.0.17",
-        "@smithy/invalid-dependency": "^2.0.15",
-        "@smithy/middleware-content-length": "^2.0.17",
-        "@smithy/middleware-endpoint": "^2.2.3",
-        "@smithy/middleware-retry": "^2.0.25",
-        "@smithy/middleware-serde": "^2.0.15",
-        "@smithy/middleware-stack": "^2.0.9",
-        "@smithy/node-config-provider": "^2.1.8",
-        "@smithy/node-http-handler": "^2.2.1",
-        "@smithy/protocol-http": "^3.0.11",
-        "@smithy/smithy-client": "^2.2.0",
-        "@smithy/types": "^2.7.0",
-        "@smithy/url-parser": "^2.0.15",
+        "@aws-sdk/core": "3.490.0",
+        "@aws-sdk/middleware-host-header": "3.489.0",
+        "@aws-sdk/middleware-logger": "3.489.0",
+        "@aws-sdk/middleware-recursion-detection": "3.489.0",
+        "@aws-sdk/middleware-user-agent": "3.489.0",
+        "@aws-sdk/region-config-resolver": "3.489.0",
+        "@aws-sdk/types": "3.489.0",
+        "@aws-sdk/util-endpoints": "3.489.0",
+        "@aws-sdk/util-user-agent-browser": "3.489.0",
+        "@aws-sdk/util-user-agent-node": "3.489.0",
+        "@smithy/config-resolver": "^2.0.23",
+        "@smithy/core": "^1.2.2",
+        "@smithy/fetch-http-handler": "^2.3.2",
+        "@smithy/hash-node": "^2.0.18",
+        "@smithy/invalid-dependency": "^2.0.16",
+        "@smithy/middleware-content-length": "^2.0.18",
+        "@smithy/middleware-endpoint": "^2.3.0",
+        "@smithy/middleware-retry": "^2.0.26",
+        "@smithy/middleware-serde": "^2.0.16",
+        "@smithy/middleware-stack": "^2.0.10",
+        "@smithy/node-config-provider": "^2.1.9",
+        "@smithy/node-http-handler": "^2.2.2",
+        "@smithy/protocol-http": "^3.0.12",
+        "@smithy/smithy-client": "^2.2.1",
+        "@smithy/types": "^2.8.0",
+        "@smithy/url-parser": "^2.0.16",
         "@smithy/util-base64": "^2.0.1",
         "@smithy/util-body-length-browser": "^2.0.1",
         "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.23",
-        "@smithy/util-defaults-mode-node": "^2.0.31",
-        "@smithy/util-endpoints": "^1.0.7",
-        "@smithy/util-retry": "^2.0.8",
+        "@smithy/util-defaults-mode-browser": "^2.0.24",
+        "@smithy/util-defaults-mode-node": "^2.0.32",
+        "@smithy/util-endpoints": "^1.0.8",
+        "@smithy/util-retry": "^2.0.9",
         "@smithy/util-utf8": "^2.0.2",
         "tslib": "^2.5.0"
       },
@@ -264,48 +264,48 @@
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.484.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.484.0.tgz",
-      "integrity": "sha512-psQxH0mYhTVvZhfca3s9NbXgnuOM8l+5LtF7fZBF5y4xaPpfAPicPWp6po69J3ynwyXi/MpHNXd/13d/L09TTA==",
+      "version": "3.490.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.490.0.tgz",
+      "integrity": "sha512-n2vQ5Qu2qi2I0XMI+IH99ElpIRHOJTa1+sqNC4juMYxKQBMvw+EnsqUtaL3QvTHoyxNB/R7mpkeBB6SzPQ1TtA==",
       "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/core": "3.481.0",
-        "@aws-sdk/credential-provider-node": "3.484.0",
-        "@aws-sdk/middleware-host-header": "3.468.0",
-        "@aws-sdk/middleware-logger": "3.468.0",
-        "@aws-sdk/middleware-recursion-detection": "3.468.0",
-        "@aws-sdk/middleware-user-agent": "3.478.0",
-        "@aws-sdk/region-config-resolver": "3.484.0",
-        "@aws-sdk/types": "3.468.0",
-        "@aws-sdk/util-endpoints": "3.478.0",
-        "@aws-sdk/util-user-agent-browser": "3.468.0",
-        "@aws-sdk/util-user-agent-node": "3.470.0",
-        "@smithy/config-resolver": "^2.0.22",
-        "@smithy/core": "^1.2.1",
-        "@smithy/fetch-http-handler": "^2.3.1",
-        "@smithy/hash-node": "^2.0.17",
-        "@smithy/invalid-dependency": "^2.0.15",
-        "@smithy/middleware-content-length": "^2.0.17",
-        "@smithy/middleware-endpoint": "^2.2.3",
-        "@smithy/middleware-retry": "^2.0.25",
-        "@smithy/middleware-serde": "^2.0.15",
-        "@smithy/middleware-stack": "^2.0.9",
-        "@smithy/node-config-provider": "^2.1.8",
-        "@smithy/node-http-handler": "^2.2.1",
-        "@smithy/protocol-http": "^3.0.11",
-        "@smithy/smithy-client": "^2.2.0",
-        "@smithy/types": "^2.7.0",
-        "@smithy/url-parser": "^2.0.15",
+        "@aws-sdk/core": "3.490.0",
+        "@aws-sdk/credential-provider-node": "3.490.0",
+        "@aws-sdk/middleware-host-header": "3.489.0",
+        "@aws-sdk/middleware-logger": "3.489.0",
+        "@aws-sdk/middleware-recursion-detection": "3.489.0",
+        "@aws-sdk/middleware-user-agent": "3.489.0",
+        "@aws-sdk/region-config-resolver": "3.489.0",
+        "@aws-sdk/types": "3.489.0",
+        "@aws-sdk/util-endpoints": "3.489.0",
+        "@aws-sdk/util-user-agent-browser": "3.489.0",
+        "@aws-sdk/util-user-agent-node": "3.489.0",
+        "@smithy/config-resolver": "^2.0.23",
+        "@smithy/core": "^1.2.2",
+        "@smithy/fetch-http-handler": "^2.3.2",
+        "@smithy/hash-node": "^2.0.18",
+        "@smithy/invalid-dependency": "^2.0.16",
+        "@smithy/middleware-content-length": "^2.0.18",
+        "@smithy/middleware-endpoint": "^2.3.0",
+        "@smithy/middleware-retry": "^2.0.26",
+        "@smithy/middleware-serde": "^2.0.16",
+        "@smithy/middleware-stack": "^2.0.10",
+        "@smithy/node-config-provider": "^2.1.9",
+        "@smithy/node-http-handler": "^2.2.2",
+        "@smithy/protocol-http": "^3.0.12",
+        "@smithy/smithy-client": "^2.2.1",
+        "@smithy/types": "^2.8.0",
+        "@smithy/url-parser": "^2.0.16",
         "@smithy/util-base64": "^2.0.1",
         "@smithy/util-body-length-browser": "^2.0.1",
         "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.23",
-        "@smithy/util-defaults-mode-node": "^2.0.31",
-        "@smithy/util-endpoints": "^1.0.7",
-        "@smithy/util-middleware": "^2.0.8",
-        "@smithy/util-retry": "^2.0.8",
+        "@smithy/util-defaults-mode-browser": "^2.0.24",
+        "@smithy/util-defaults-mode-node": "^2.0.32",
+        "@smithy/util-endpoints": "^1.0.8",
+        "@smithy/util-middleware": "^2.0.9",
+        "@smithy/util-retry": "^2.0.9",
         "@smithy/util-utf8": "^2.0.2",
         "fast-xml-parser": "4.2.5",
         "tslib": "^2.5.0"
@@ -315,16 +315,16 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.481.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.481.0.tgz",
-      "integrity": "sha512-UeyAc2FnWQDts81vPVBWKEj0WagYK4SVAgNfGcg6zCzzqsUG4unr4NPKQoca2L+XOU55yMCy+5l2K6R3YsFGKg==",
+      "version": "3.490.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.490.0.tgz",
+      "integrity": "sha512-TSBWkXtxMU7q1Zo6w3v5wIOr/sj7P5Jw3OyO7lJrFGsPsDC2xwpxkVqTesDxkzgMRypO52xjYEmveagn1xxBHg==",
       "peer": true,
       "dependencies": {
-        "@smithy/core": "^1.2.1",
-        "@smithy/protocol-http": "^3.0.11",
+        "@smithy/core": "^1.2.2",
+        "@smithy/protocol-http": "^3.0.12",
         "@smithy/signature-v4": "^2.0.0",
-        "@smithy/smithy-client": "^2.2.0",
-        "@smithy/types": "^2.7.0",
+        "@smithy/smithy-client": "^2.2.1",
+        "@smithy/types": "^2.8.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -332,14 +332,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.468.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.468.0.tgz",
-      "integrity": "sha512-k/1WHd3KZn0EQYjadooj53FC0z24/e4dUZhbSKTULgmxyO62pwh9v3Brvw4WRa/8o2wTffU/jo54tf4vGuP/ZA==",
+      "version": "3.489.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.489.0.tgz",
+      "integrity": "sha512-5PqYsx9G5SB2tqPT9/z/u0EkF6D4wP6HTMWQs+DfMdmwXihrqQAgeYaTtV3KbXqb88p6sfacwxhUvE6+Rm494w==",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "3.468.0",
+        "@aws-sdk/types": "3.489.0",
         "@smithy/property-provider": "^2.0.0",
-        "@smithy/types": "^2.7.0",
+        "@smithy/types": "^2.8.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -347,20 +347,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.484.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.484.0.tgz",
-      "integrity": "sha512-BbvU7seI0RPPwpujnz4LA1lC53Cj4BOSRpYYZbrxA6C7SzW0D/IQBZQP3JBbrxIhqewSROSsYGDjvYbyi5aDEw==",
+      "version": "3.490.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.490.0.tgz",
+      "integrity": "sha512-7m63zyCpVqj9FsoDxWMWWRvL6c7zZzOcXYkHZmHujVVlmAXH0RT/vkXFkYgt+Ku+ov+v5NQrzwO5TmVoRt6O8g==",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.468.0",
-        "@aws-sdk/credential-provider-process": "3.468.0",
-        "@aws-sdk/credential-provider-sso": "3.484.0",
-        "@aws-sdk/credential-provider-web-identity": "3.468.0",
-        "@aws-sdk/types": "3.468.0",
+        "@aws-sdk/credential-provider-env": "3.489.0",
+        "@aws-sdk/credential-provider-process": "3.489.0",
+        "@aws-sdk/credential-provider-sso": "3.490.0",
+        "@aws-sdk/credential-provider-web-identity": "3.489.0",
+        "@aws-sdk/types": "3.489.0",
         "@smithy/credential-provider-imds": "^2.0.0",
         "@smithy/property-provider": "^2.0.0",
         "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/types": "^2.7.0",
+        "@smithy/types": "^2.8.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -368,21 +368,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.484.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.484.0.tgz",
-      "integrity": "sha512-Ylqej3FqRwUD3I7929k214LRH1bUz7f2hfV4ZqY7teM9hQC5Ov5SpVtOtLKNfgaaxAkhD2ffMNfmq8TAg824+g==",
+      "version": "3.490.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.490.0.tgz",
+      "integrity": "sha512-Gh33u2O5Xbout8G3z/Z5H/CZzdG1ophxf/XS3iMFxA1cazQ7swY1UMmGvB7Lm7upvax5anXouItD1Ph3gzKc4w==",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.468.0",
-        "@aws-sdk/credential-provider-ini": "3.484.0",
-        "@aws-sdk/credential-provider-process": "3.468.0",
-        "@aws-sdk/credential-provider-sso": "3.484.0",
-        "@aws-sdk/credential-provider-web-identity": "3.468.0",
-        "@aws-sdk/types": "3.468.0",
+        "@aws-sdk/credential-provider-env": "3.489.0",
+        "@aws-sdk/credential-provider-ini": "3.490.0",
+        "@aws-sdk/credential-provider-process": "3.489.0",
+        "@aws-sdk/credential-provider-sso": "3.490.0",
+        "@aws-sdk/credential-provider-web-identity": "3.489.0",
+        "@aws-sdk/types": "3.489.0",
         "@smithy/credential-provider-imds": "^2.0.0",
         "@smithy/property-provider": "^2.0.0",
         "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/types": "^2.7.0",
+        "@smithy/types": "^2.8.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -390,15 +390,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.468.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.468.0.tgz",
-      "integrity": "sha512-OYSn1A/UsyPJ7Z8Q2cNhTf55O36shPmSsvOfND04nSfu1nPaR+VUvvsP7v+brhGpwC/GAKTIdGAo4blH31BS6A==",
+      "version": "3.489.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.489.0.tgz",
+      "integrity": "sha512-3vKQYJZ5cZYjy0870CPmbmKRBgATw2xCygxhn4m4UDCjOXVXcGUtYD51DMWsvBo3S0W8kH+FIJV4yuEDMFqLFQ==",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "3.468.0",
+        "@aws-sdk/types": "3.489.0",
         "@smithy/property-provider": "^2.0.0",
         "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/types": "^2.7.0",
+        "@smithy/types": "^2.8.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -406,17 +406,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.484.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.484.0.tgz",
-      "integrity": "sha512-Fl7+YhrlU2icZkz18z9aj4SiWb2aQlWp5LsVqMfSzTlJFc9yPlD9e7F33gnL7kKLVSnAVxsr5v4y4pFC6FZUSw==",
+      "version": "3.490.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.490.0.tgz",
+      "integrity": "sha512-3UUBUoPbFvT58IhS4Vb23omYj/QPNkjgxu9p9ruQ3KSjLkanI4w8t/l/jljA65q83P7CoLnM5UKG9L7RA8/V1Q==",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/client-sso": "3.484.0",
-        "@aws-sdk/token-providers": "3.484.0",
-        "@aws-sdk/types": "3.468.0",
+        "@aws-sdk/client-sso": "3.490.0",
+        "@aws-sdk/token-providers": "3.489.0",
+        "@aws-sdk/types": "3.489.0",
         "@smithy/property-provider": "^2.0.0",
         "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/types": "^2.7.0",
+        "@smithy/types": "^2.8.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -424,14 +424,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.468.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.468.0.tgz",
-      "integrity": "sha512-rexymPmXjtkwCPfhnUq3EjO1rSkf39R4Jz9CqiM7OsqK2qlT5Y/V3gnMKn0ZMXsYaQOMfM3cT5xly5R+OKDHlw==",
+      "version": "3.489.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.489.0.tgz",
+      "integrity": "sha512-mjIuE2Wg1H/ds0nXQ/7vfusEDudmdd8YzKZI1y5O4n60iZZtyB2RNIECtvLMx1EQAKclidY7/06qQkArrGau5Q==",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "3.468.0",
+        "@aws-sdk/types": "3.489.0",
         "@smithy/property-provider": "^2.0.0",
-        "@smithy/types": "^2.7.0",
+        "@smithy/types": "^2.8.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -439,14 +439,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.468.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.468.0.tgz",
-      "integrity": "sha512-gwQ+/QhX+lhof304r6zbZ/V5l5cjhGRxLL3CjH1uJPMcOAbw9wUlMdl+ibr8UwBZ5elfKFGiB1cdW/0uMchw0w==",
+      "version": "3.489.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.489.0.tgz",
+      "integrity": "sha512-Cl7HJ1jhOfllwf0CRx1eB4ypRGMqdGKWpc0eSTXty7wWSvCdMZUhwfjQqu2bIOIlgYxg/gFu6TVmVZ6g4O8PlA==",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "3.468.0",
-        "@smithy/protocol-http": "^3.0.11",
-        "@smithy/types": "^2.7.0",
+        "@aws-sdk/types": "3.489.0",
+        "@smithy/protocol-http": "^3.0.12",
+        "@smithy/types": "^2.8.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -454,13 +454,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.468.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.468.0.tgz",
-      "integrity": "sha512-X5XHKV7DHRXI3f29SAhJPe/OxWRFgDWDMMCALfzhmJfCi6Jfh0M14cJKoC+nl+dk9lB+36+jKjhjETZaL2bPlA==",
+      "version": "3.489.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.489.0.tgz",
+      "integrity": "sha512-+EVDnWese61MdImcBNAgz/AhTcIZJaska/xsU3GWU9CP905x4a4qZdB7fExFMDu1Jlz5pJqNteFYYHCFMJhHfg==",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "3.468.0",
-        "@smithy/types": "^2.7.0",
+        "@aws-sdk/types": "3.489.0",
+        "@smithy/types": "^2.8.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -468,14 +468,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.468.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.468.0.tgz",
-      "integrity": "sha512-vch9IQib2Ng9ucSyRW2eKNQXHUPb5jUPCLA5otTW/8nGjcOU37LxQG4WrxO7uaJ9Oe8hjHO+hViE3P0KISUhtA==",
+      "version": "3.489.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.489.0.tgz",
+      "integrity": "sha512-m4rU+fTzziQcu9DKjRNZ4nQlXENEd2ZnJblJV4ONdWqqEjbmOgOj3P6aCCQlJdIbzuNvX1FBOZ5tY59ZpERo7Q==",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "3.468.0",
-        "@smithy/protocol-http": "^3.0.11",
-        "@smithy/types": "^2.7.0",
+        "@aws-sdk/types": "3.489.0",
+        "@smithy/protocol-http": "^3.0.12",
+        "@smithy/types": "^2.8.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -483,17 +483,17 @@
       }
     },
     "node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.468.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.468.0.tgz",
-      "integrity": "sha512-s+7fSB1gdnnTj5O0aCCarX3z5Vppop8kazbNSZADdkfHIDWCN80IH4ZNjY3OWqaAz0HmR4LNNrovdR304ojb4Q==",
+      "version": "3.489.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.489.0.tgz",
+      "integrity": "sha512-rlHcWYZn6Ym3v/u0DvKNDiD7ogIzEsHlerm0lowTiQbszkFobOiUClRTALwvsUZdAAztl706qO1OKbnGnD6Ubw==",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "3.468.0",
+        "@aws-sdk/types": "3.489.0",
         "@smithy/property-provider": "^2.0.0",
-        "@smithy/protocol-http": "^3.0.11",
+        "@smithy/protocol-http": "^3.0.12",
         "@smithy/signature-v4": "^2.0.0",
-        "@smithy/types": "^2.7.0",
-        "@smithy/util-middleware": "^2.0.8",
+        "@smithy/types": "^2.8.0",
+        "@smithy/util-middleware": "^2.0.9",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -501,15 +501,15 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.478.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.478.0.tgz",
-      "integrity": "sha512-Rec+nAPIzzwxgHPW+xqY6tooJGFOytpYg/xSRv8/IXl3xKGhmpMGs6gDWzmMBv/qy5nKTvLph/csNWJ98GWXCw==",
+      "version": "3.489.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.489.0.tgz",
+      "integrity": "sha512-M54Cv2fAN3GGgdfUjLtZ4wFUIrfM/ivbXv4DgpcNsacEQ2g4H+weQgKp41X7XZW8MWAzl+k1zJaryK69RYNQkQ==",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "3.468.0",
-        "@aws-sdk/util-endpoints": "3.478.0",
-        "@smithy/protocol-http": "^3.0.11",
-        "@smithy/types": "^2.7.0",
+        "@aws-sdk/types": "3.489.0",
+        "@aws-sdk/util-endpoints": "3.489.0",
+        "@smithy/protocol-http": "^3.0.12",
+        "@smithy/types": "^2.8.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -517,15 +517,16 @@
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.484.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.484.0.tgz",
-      "integrity": "sha512-qfYSwSIc9GasHFrJidydlQE433mB93d31dfypFWhrJPXRv1fhopO72NSfsY2WCcbaRkADc4AajLZFly4J96abw==",
+      "version": "3.489.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.489.0.tgz",
+      "integrity": "sha512-UvrnB78XTz9ddby7mr0vuUHn2MO3VTjzaIu+GQhyedMGQU0QlIQrYOlzbbu4LC5rL1O8FxFLUxRe/AAjgwyuGw==",
       "peer": true,
       "dependencies": {
-        "@smithy/node-config-provider": "^2.1.8",
-        "@smithy/types": "^2.7.0",
+        "@aws-sdk/types": "3.489.0",
+        "@smithy/node-config-provider": "^2.1.9",
+        "@smithy/types": "^2.8.0",
         "@smithy/util-config-provider": "^2.1.0",
-        "@smithy/util-middleware": "^2.0.8",
+        "@smithy/util-middleware": "^2.0.9",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -533,46 +534,46 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.484.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.484.0.tgz",
-      "integrity": "sha512-9Eb7X0sNhJANfYCeEYWCvfeD4shMZEse3YUz5EALzbpzi/So56ZaeA/lWWeh0fkYiByq74eA2QkC/tXZkHw6EQ==",
+      "version": "3.489.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.489.0.tgz",
+      "integrity": "sha512-hSgjB8CMQoA8EIQ0ripDjDtbBcWDSa+7vSBYPIzksyknaGERR/GUfGXLV2dpm5t17FgFG6irT5f3ZlBzarL8Dw==",
       "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/middleware-host-header": "3.468.0",
-        "@aws-sdk/middleware-logger": "3.468.0",
-        "@aws-sdk/middleware-recursion-detection": "3.468.0",
-        "@aws-sdk/middleware-user-agent": "3.478.0",
-        "@aws-sdk/region-config-resolver": "3.484.0",
-        "@aws-sdk/types": "3.468.0",
-        "@aws-sdk/util-endpoints": "3.478.0",
-        "@aws-sdk/util-user-agent-browser": "3.468.0",
-        "@aws-sdk/util-user-agent-node": "3.470.0",
-        "@smithy/config-resolver": "^2.0.22",
-        "@smithy/fetch-http-handler": "^2.3.1",
-        "@smithy/hash-node": "^2.0.17",
-        "@smithy/invalid-dependency": "^2.0.15",
-        "@smithy/middleware-content-length": "^2.0.17",
-        "@smithy/middleware-endpoint": "^2.2.3",
-        "@smithy/middleware-retry": "^2.0.25",
-        "@smithy/middleware-serde": "^2.0.15",
-        "@smithy/middleware-stack": "^2.0.9",
-        "@smithy/node-config-provider": "^2.1.8",
-        "@smithy/node-http-handler": "^2.2.1",
+        "@aws-sdk/middleware-host-header": "3.489.0",
+        "@aws-sdk/middleware-logger": "3.489.0",
+        "@aws-sdk/middleware-recursion-detection": "3.489.0",
+        "@aws-sdk/middleware-user-agent": "3.489.0",
+        "@aws-sdk/region-config-resolver": "3.489.0",
+        "@aws-sdk/types": "3.489.0",
+        "@aws-sdk/util-endpoints": "3.489.0",
+        "@aws-sdk/util-user-agent-browser": "3.489.0",
+        "@aws-sdk/util-user-agent-node": "3.489.0",
+        "@smithy/config-resolver": "^2.0.23",
+        "@smithy/fetch-http-handler": "^2.3.2",
+        "@smithy/hash-node": "^2.0.18",
+        "@smithy/invalid-dependency": "^2.0.16",
+        "@smithy/middleware-content-length": "^2.0.18",
+        "@smithy/middleware-endpoint": "^2.3.0",
+        "@smithy/middleware-retry": "^2.0.26",
+        "@smithy/middleware-serde": "^2.0.16",
+        "@smithy/middleware-stack": "^2.0.10",
+        "@smithy/node-config-provider": "^2.1.9",
+        "@smithy/node-http-handler": "^2.2.2",
         "@smithy/property-provider": "^2.0.0",
-        "@smithy/protocol-http": "^3.0.11",
+        "@smithy/protocol-http": "^3.0.12",
         "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/smithy-client": "^2.2.0",
-        "@smithy/types": "^2.7.0",
-        "@smithy/url-parser": "^2.0.15",
+        "@smithy/smithy-client": "^2.2.1",
+        "@smithy/types": "^2.8.0",
+        "@smithy/url-parser": "^2.0.16",
         "@smithy/util-base64": "^2.0.1",
         "@smithy/util-body-length-browser": "^2.0.1",
         "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.23",
-        "@smithy/util-defaults-mode-node": "^2.0.31",
-        "@smithy/util-endpoints": "^1.0.7",
-        "@smithy/util-retry": "^2.0.8",
+        "@smithy/util-defaults-mode-browser": "^2.0.24",
+        "@smithy/util-defaults-mode-node": "^2.0.32",
+        "@smithy/util-endpoints": "^1.0.8",
+        "@smithy/util-retry": "^2.0.9",
         "@smithy/util-utf8": "^2.0.2",
         "tslib": "^2.5.0"
       },
@@ -581,12 +582,12 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.468.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.468.0.tgz",
-      "integrity": "sha512-rx/9uHI4inRbp2tw3Y4Ih4PNZkVj32h7WneSg3MVgVjAoVD5Zti9KhS5hkvsBxfgmQmg0AQbE+b1sy5WGAgntA==",
+      "version": "3.489.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.489.0.tgz",
+      "integrity": "sha512-kcDtLfKog/p0tC4gAeqJqWxAiEzfe2LRPnKamvSG2Mjbthx4R/alE2dxyIq/wW+nvRv0fqR3OD5kD1+eVfdr/w==",
       "peer": true,
       "dependencies": {
-        "@smithy/types": "^2.7.0",
+        "@smithy/types": "^2.8.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -594,13 +595,14 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.478.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.478.0.tgz",
-      "integrity": "sha512-u9Mcg3euGJGs5clPt9mBuhBjHiEKiD0PnfvArhfq9i+dcY5mbCq/i1Dezp3iv1fZH9xxQt7hPXDfSpt1yUSM6g==",
+      "version": "3.489.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.489.0.tgz",
+      "integrity": "sha512-uGyG1u84ATX03mf7bT4xD9XD/vlYJGD5+RxMN/UpzeTfzXfh+jvCQWbOQ44z8ttFJWYQQqrLxkfpF/JgvALzLA==",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "3.468.0",
-        "@smithy/util-endpoints": "^1.0.7",
+        "@aws-sdk/types": "3.489.0",
+        "@smithy/types": "^2.8.0",
+        "@smithy/util-endpoints": "^1.0.8",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -620,26 +622,26 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.468.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.468.0.tgz",
-      "integrity": "sha512-OJyhWWsDEizR3L+dCgMXSUmaCywkiZ7HSbnQytbeKGwokIhD69HTiJcibF/sgcM5gk4k3Mq3puUhGnEZ46GIig==",
+      "version": "3.489.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.489.0.tgz",
+      "integrity": "sha512-85B9KMsuMpAZauzWQ16r52ZBAHYnznW6BVitnBglsibN7oJKn10Hggt4QGuRhvQFCxQ8YhvBl7r+vQGFO4hxIw==",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "3.468.0",
-        "@smithy/types": "^2.7.0",
+        "@aws-sdk/types": "3.489.0",
+        "@smithy/types": "^2.8.0",
         "bowser": "^2.11.0",
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.470.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.470.0.tgz",
-      "integrity": "sha512-QxsZ9iVHcBB/XRdYvwfM5AMvNp58HfqkIrH88mY0cmxuvtlIGDfWjczdDrZMJk9y0vIq+cuoCHsGXHu7PyiEAQ==",
+      "version": "3.489.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.489.0.tgz",
+      "integrity": "sha512-CYdkBHig8sFNc0dv11Ni9WXvZQHeI5+z77OrDHKkbidFx/V4BDTuwZw4K1vWg62pzFOEfzunJFiULRcDZWJR3w==",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "3.468.0",
-        "@smithy/node-config-provider": "^2.1.8",
-        "@smithy/types": "^2.7.0",
+        "@aws-sdk/types": "3.489.0",
+        "@smithy/node-config-provider": "^2.1.9",
+        "@smithy/types": "^2.8.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -943,9 +945,9 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.23.7",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.7.tgz",
-      "integrity": "sha512-6AMnjCoC8wjqBzDHkuqpa7jAKwvMo4dC+lr/TFBz+ucfulO1XMpDnwWPGBNwClOKZ8h6xn5N81W/R5OrcKtCbQ==",
+      "version": "7.23.8",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.8.tgz",
+      "integrity": "sha512-KDqYz4PiOWvDFrdHLPhKtCThtIcKVy6avWD2oG4GEvyQ+XDZwHD4YQd+H2vNMnq2rkdxsDkU82T+Vk8U/WXHRQ==",
       "dev": true,
       "dependencies": {
         "@babel/template": "^7.22.15",
@@ -2017,9 +2019,9 @@
       "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.20",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz",
-      "integrity": "sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==",
+      "version": "0.3.21",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.21.tgz",
+      "integrity": "sha512-SRfKmRe1KvYnxjEMtxEr+J4HIeMX5YBg/qhRHpxEIGjhX1rshcHlnFUE9K0GazhVKWM7B+nARSkV8LuvJdJ5/g==",
       "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -2051,12 +2053,12 @@
       }
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.15.tgz",
-      "integrity": "sha512-JkS36PIS3/UCbq/MaozzV7jECeL+BTt4R75bwY8i+4RASys4xOyUS1HsRyUNSqUXFP4QyCz5aNnh3ltuaxv+pw==",
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.16.tgz",
+      "integrity": "sha512-4foO7738k8kM9flMHu3VLabqu7nPgvIj8TB909S0CnKx0YZz/dcDH3pZ/4JHdatfxlZdKF1JWOYCw9+v3HVVsw==",
       "peer": true,
       "dependencies": {
-        "@smithy/types": "^2.7.0",
+        "@smithy/types": "^2.8.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2064,15 +2066,15 @@
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "2.0.22",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.22.tgz",
-      "integrity": "sha512-YuPjsLnq6I5ZQBTx6BL5NsCLtcLel5YIMf3gDeEa+GSCXn5mgRXm+8XO8HtjR3Xf69b88aY4c7bwKQQS2i8vtA==",
+      "version": "2.0.23",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.23.tgz",
+      "integrity": "sha512-XakUqgtP2YY8Mi+Nlif5BiqJgWdvfxJafSpOSQeCOMizu+PUhE4fBQSy6xFcR+eInrwVadaABNxoJyGUMn15ew==",
       "peer": true,
       "dependencies": {
-        "@smithy/node-config-provider": "^2.1.8",
-        "@smithy/types": "^2.7.0",
+        "@smithy/node-config-provider": "^2.1.9",
+        "@smithy/types": "^2.8.0",
         "@smithy/util-config-provider": "^2.1.0",
-        "@smithy/util-middleware": "^2.0.8",
+        "@smithy/util-middleware": "^2.0.9",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2080,18 +2082,18 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-1.2.1.tgz",
-      "integrity": "sha512-f6cwmMuHo7RIw/c184NBd2rGeGvGIX6p55HSrG5jfR3qkNYo80PHRfhzkJMq1+mv1ZjI5p8NhenWMMkIRJR4tw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-1.2.2.tgz",
+      "integrity": "sha512-uLjrskLT+mWb0emTR5QaiAIxVEU7ndpptDaVDrTwwhD+RjvHhjIiGQ3YL5jKk1a5VSDQUA2RGkXvJ6XKRcz6Dg==",
       "peer": true,
       "dependencies": {
-        "@smithy/middleware-endpoint": "^2.2.3",
-        "@smithy/middleware-retry": "^2.0.25",
-        "@smithy/middleware-serde": "^2.0.15",
-        "@smithy/protocol-http": "^3.0.11",
-        "@smithy/smithy-client": "^2.2.0",
-        "@smithy/types": "^2.7.0",
-        "@smithy/util-middleware": "^2.0.8",
+        "@smithy/middleware-endpoint": "^2.3.0",
+        "@smithy/middleware-retry": "^2.0.26",
+        "@smithy/middleware-serde": "^2.0.16",
+        "@smithy/protocol-http": "^3.0.12",
+        "@smithy/smithy-client": "^2.2.1",
+        "@smithy/types": "^2.8.0",
+        "@smithy/util-middleware": "^2.0.9",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2099,15 +2101,15 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.1.4.tgz",
-      "integrity": "sha512-cwPJN1fa1YOQzhBlTXRavABEYRRchci1X79QRwzaNLySnIMJfztyv1Zkst0iZPLMnpn8+CnHu3wOHS11J5Dr3A==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.1.5.tgz",
+      "integrity": "sha512-VfvE6Wg1MUWwpTZFBnUD7zxvPhLY8jlHCzu6bCjlIYoWgXCDzZAML76IlZUEf45nib3rjehnFgg0s1rgsuN/bg==",
       "peer": true,
       "dependencies": {
-        "@smithy/node-config-provider": "^2.1.8",
-        "@smithy/property-provider": "^2.0.16",
-        "@smithy/types": "^2.7.0",
-        "@smithy/url-parser": "^2.0.15",
+        "@smithy/node-config-provider": "^2.1.9",
+        "@smithy/property-provider": "^2.0.17",
+        "@smithy/types": "^2.8.0",
+        "@smithy/url-parser": "^2.0.16",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2115,37 +2117,37 @@
       }
     },
     "node_modules/@smithy/eventstream-codec": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.0.15.tgz",
-      "integrity": "sha512-crjvz3j1gGPwA0us6cwS7+5gAn35CTmqu/oIxVbYJo2Qm/sGAye6zGJnMDk3BKhWZw5kcU1G4MxciTkuBpOZPg==",
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.0.16.tgz",
+      "integrity": "sha512-umYh5pdCE9GHgiMAH49zu9wXWZKNHHdKPm/lK22WYISTjqu29SepmpWNmPiBLy/yUu4HFEGJHIFrDWhbDlApaw==",
       "peer": true,
       "dependencies": {
         "@aws-crypto/crc32": "3.0.0",
-        "@smithy/types": "^2.7.0",
+        "@smithy/types": "^2.8.0",
         "@smithy/util-hex-encoding": "^2.0.0",
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.3.1.tgz",
-      "integrity": "sha512-6MNk16fqb8EwcYY8O8WxB3ArFkLZ2XppsSNo1h7SQcFdDDwIumiJeO6wRzm7iB68xvsOQzsdQKbdtTieS3hfSQ==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.3.2.tgz",
+      "integrity": "sha512-O9R/OlnAOTsnysuSDjt0v2q6DcSvCz5cCFC/CFAWWcLyBwJDeFyGTCTszgpQTb19+Fi8uRwZE5/3ziAQBFeDMQ==",
       "peer": true,
       "dependencies": {
-        "@smithy/protocol-http": "^3.0.11",
-        "@smithy/querystring-builder": "^2.0.15",
-        "@smithy/types": "^2.7.0",
+        "@smithy/protocol-http": "^3.0.12",
+        "@smithy/querystring-builder": "^2.0.16",
+        "@smithy/types": "^2.8.0",
         "@smithy/util-base64": "^2.0.1",
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "2.0.17",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.17.tgz",
-      "integrity": "sha512-Il6WuBcI1nD+e2DM7tTADMf01wEPGK8PAhz4D+YmDUVaoBqlA+CaH2uDJhiySifmuKBZj748IfygXty81znKhw==",
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.18.tgz",
+      "integrity": "sha512-gN2JFvAgnZCyDN9rJgcejfpK0uPPJrSortVVVVWsru9whS7eQey6+gj2eM5ln2i6rHNntIXzal1Fm9XOPuoaKA==",
       "peer": true,
       "dependencies": {
-        "@smithy/types": "^2.7.0",
+        "@smithy/types": "^2.8.0",
         "@smithy/util-buffer-from": "^2.0.0",
         "@smithy/util-utf8": "^2.0.2",
         "tslib": "^2.5.0"
@@ -2155,12 +2157,12 @@
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.15.tgz",
-      "integrity": "sha512-dlEKBFFwVfzA5QroHlBS94NpgYjXhwN/bFfun+7w3rgxNvVy79SK0w05iGc7UAeC5t+D7gBxrzdnD6hreZnDVQ==",
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.16.tgz",
+      "integrity": "sha512-apEHakT/kmpNo1VFHP4W/cjfeP9U0x5qvfsLJubgp7UM/gq4qYp0GbqdE7QhsjUaYvEnrftRqs7+YrtWreV0wA==",
       "peer": true,
       "dependencies": {
-        "@smithy/types": "^2.7.0",
+        "@smithy/types": "^2.8.0",
         "tslib": "^2.5.0"
       }
     },
@@ -2177,13 +2179,13 @@
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "2.0.17",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.17.tgz",
-      "integrity": "sha512-OyadvMcKC7lFXTNBa8/foEv7jOaqshQZkjWS9coEXPRZnNnihU/Ls+8ZuJwGNCOrN2WxXZFmDWhegbnM4vak8w==",
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.18.tgz",
+      "integrity": "sha512-ZJ9uKPTfxYheTKSKYB+GCvcj+izw9WGzRLhjn8n254q0jWLojUzn7Vw0l4R/Gq7Wdpf/qmk/ptD+6CCXHNVCaw==",
       "peer": true,
       "dependencies": {
-        "@smithy/protocol-http": "^3.0.11",
-        "@smithy/types": "^2.7.0",
+        "@smithy/protocol-http": "^3.0.12",
+        "@smithy/types": "^2.8.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2191,17 +2193,17 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.2.3.tgz",
-      "integrity": "sha512-nYfxuq0S/xoAjdLbyn1ixeVB6cyH9wYCMtbbOCpcCRYR5u2mMtqUtVjjPAZ/DIdlK3qe0tpB0Q76szFGNuz+kQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.3.0.tgz",
+      "integrity": "sha512-VsOAG2YQ8ykjSmKO+CIXdJBIWFo6AAvG6Iw95BakBTqk66/4BI7XyqLevoNSq/lZ6NgZv24sLmrcIN+fLDWBCg==",
       "peer": true,
       "dependencies": {
-        "@smithy/middleware-serde": "^2.0.15",
-        "@smithy/node-config-provider": "^2.1.8",
-        "@smithy/shared-ini-file-loader": "^2.2.7",
-        "@smithy/types": "^2.7.0",
-        "@smithy/url-parser": "^2.0.15",
-        "@smithy/util-middleware": "^2.0.8",
+        "@smithy/middleware-serde": "^2.0.16",
+        "@smithy/node-config-provider": "^2.1.9",
+        "@smithy/shared-ini-file-loader": "^2.2.8",
+        "@smithy/types": "^2.8.0",
+        "@smithy/url-parser": "^2.0.16",
+        "@smithy/util-middleware": "^2.0.9",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2209,18 +2211,18 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "2.0.25",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.25.tgz",
-      "integrity": "sha512-FXhafCPvx/9L9OgHJ3cdo/pD1f7ngC7DKsjDV2J7k6LO/Yl69POoBLk4sI1OZPUGc4dfxriENlTma9Nj1hI+IQ==",
+      "version": "2.0.26",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.26.tgz",
+      "integrity": "sha512-Qzpxo0U5jfNiq9iD38U3e2bheXwvTEX4eue9xruIvEgh+UKq6dKuGqcB66oBDV7TD/mfoJi9Q/VmaiqwWbEp7A==",
       "peer": true,
       "dependencies": {
-        "@smithy/node-config-provider": "^2.1.8",
-        "@smithy/protocol-http": "^3.0.11",
-        "@smithy/service-error-classification": "^2.0.8",
-        "@smithy/smithy-client": "^2.2.0",
-        "@smithy/types": "^2.7.0",
-        "@smithy/util-middleware": "^2.0.8",
-        "@smithy/util-retry": "^2.0.8",
+        "@smithy/node-config-provider": "^2.1.9",
+        "@smithy/protocol-http": "^3.0.12",
+        "@smithy/service-error-classification": "^2.0.9",
+        "@smithy/smithy-client": "^2.2.1",
+        "@smithy/types": "^2.8.0",
+        "@smithy/util-middleware": "^2.0.9",
+        "@smithy/util-retry": "^2.0.9",
         "tslib": "^2.5.0",
         "uuid": "^8.3.2"
       },
@@ -2229,12 +2231,12 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.15.tgz",
-      "integrity": "sha512-FOZRFk/zN4AT4wzGuBY+39XWe+ZnCFd0gZtyw3f9Okn2CJPixl9GyWe98TIaljeZdqWkgrzGyPre20AcW2UMHQ==",
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.16.tgz",
+      "integrity": "sha512-5EAd4t30pcc4M8TSSGq7q/x5IKrxfXR5+SrU4bgxNy7RPHQo2PSWBUco9C+D9Tfqp/JZvprRpK42dnupZafk2g==",
       "peer": true,
       "dependencies": {
-        "@smithy/types": "^2.7.0",
+        "@smithy/types": "^2.8.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2242,12 +2244,12 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.0.9.tgz",
-      "integrity": "sha512-bCB5dUtGQ5wh7QNL2ELxmDc6g7ih7jWU3Kx6MYH1h4mZbv9xL3WyhKHojRltThCB1arLPyTUFDi+x6fB/oabtA==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.0.10.tgz",
+      "integrity": "sha512-I2rbxctNq9FAPPEcuA1ntZxkTKOPQFy7YBPOaD/MLg1zCvzv21CoNxR0py6J8ZVC35l4qE4nhxB0f7TF5/+Ldw==",
       "peer": true,
       "dependencies": {
-        "@smithy/types": "^2.7.0",
+        "@smithy/types": "^2.8.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2255,14 +2257,14 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.1.8.tgz",
-      "integrity": "sha512-+w26OKakaBUGp+UG+dxYZtFb5fs3tgHg3/QrRrmUZj+rl3cIuw840vFUXX35cVPTUCQIiTqmz7CpVF7+hdINdQ==",
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.1.9.tgz",
+      "integrity": "sha512-tUyW/9xrRy+s7RXkmQhgYkAPMpTIF8izK4orhHjNFEKR3QZiOCbWB546Y8iB/Fpbm3O9+q0Af9rpywLKJOwtaQ==",
       "peer": true,
       "dependencies": {
-        "@smithy/property-provider": "^2.0.16",
-        "@smithy/shared-ini-file-loader": "^2.2.7",
-        "@smithy/types": "^2.7.0",
+        "@smithy/property-provider": "^2.0.17",
+        "@smithy/shared-ini-file-loader": "^2.2.8",
+        "@smithy/types": "^2.8.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2270,15 +2272,15 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.2.1.tgz",
-      "integrity": "sha512-8iAKQrC8+VFHPAT8pg4/j6hlsTQh+NKOWlctJBrYtQa4ExcxX7aSg3vdQ2XLoYwJotFUurg/NLqFCmZaPRrogw==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.2.2.tgz",
+      "integrity": "sha512-XO58TO/Eul/IBQKFKaaBtXJi0ItEQQCT+NI4IiKHCY/4KtqaUT6y/wC1EvDqlA9cP7Dyjdj7FdPs4DyynH3u7g==",
       "peer": true,
       "dependencies": {
-        "@smithy/abort-controller": "^2.0.15",
-        "@smithy/protocol-http": "^3.0.11",
-        "@smithy/querystring-builder": "^2.0.15",
-        "@smithy/types": "^2.7.0",
+        "@smithy/abort-controller": "^2.0.16",
+        "@smithy/protocol-http": "^3.0.12",
+        "@smithy/querystring-builder": "^2.0.16",
+        "@smithy/types": "^2.8.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2286,12 +2288,12 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.16.tgz",
-      "integrity": "sha512-28Ky0LlOqtEjwg5CdHmwwaDRHcTWfPRzkT6HrhwOSRS2RryAvuDfJrZpM+BMcrdeCyEg1mbcgIMoqTla+rdL8Q==",
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.17.tgz",
+      "integrity": "sha512-+VkeZbVu7qtQ2DjI48Qwaf9fPOr3gZIwxQpuLJgRRSkWsdSvmaTCxI3gzRFKePB63Ts9r4yjn4HkxSCSkdWmcQ==",
       "peer": true,
       "dependencies": {
-        "@smithy/types": "^2.7.0",
+        "@smithy/types": "^2.8.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2299,12 +2301,12 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.11.tgz",
-      "integrity": "sha512-3ziB8fHuXIRamV/akp/sqiWmNPR6X+9SB8Xxnozzj+Nq7hSpyKdFHd1FLpBkgfGFUTzzcBJQlDZPSyxzmdcx5A==",
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.12.tgz",
+      "integrity": "sha512-Xz4iaqLiaBfbQpB9Hgi3VcZYbP7xRDXYhd8XWChh4v94uw7qwmvlxdU5yxzfm6ACJM66phHrTbS5TVvj5uQ72w==",
       "peer": true,
       "dependencies": {
-        "@smithy/types": "^2.7.0",
+        "@smithy/types": "^2.8.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2312,12 +2314,12 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.15.tgz",
-      "integrity": "sha512-e1q85aT6HutvouOdN+dMsN0jcdshp50PSCvxDvo6aIM57LqeXimjfONUEgfqQ4IFpYWAtVixptyIRE5frMp/2A==",
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.16.tgz",
+      "integrity": "sha512-Q/GsJT0C0mijXMRs7YhZLLCP5FcuC4797lYjKQkME5CZohnLC4bEhylAd2QcD3gbMKNjCw8+T2I27WKiV/wToA==",
       "peer": true,
       "dependencies": {
-        "@smithy/types": "^2.7.0",
+        "@smithy/types": "^2.8.0",
         "@smithy/util-uri-escape": "^2.0.0",
         "tslib": "^2.5.0"
       },
@@ -2326,12 +2328,12 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.15.tgz",
-      "integrity": "sha512-jbBvoK3cc81Cj1c1TH1qMYxNQKHrYQ2DoTntN9FBbtUWcGhc+T4FP6kCKYwRLXyU4AajwGIZstvNAmIEgUUNTQ==",
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.16.tgz",
+      "integrity": "sha512-c4ueAuL6BDYKWpkubjrQthZKoC3L5kql5O++ovekNxiexRXTlLIVlCR4q3KziOktLIw66EU9SQljPXd/oN6Okg==",
       "peer": true,
       "dependencies": {
-        "@smithy/types": "^2.7.0",
+        "@smithy/types": "^2.8.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2339,24 +2341,24 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.0.8.tgz",
-      "integrity": "sha512-jCw9+005im8tsfYvwwSc4TTvd29kXRFkH9peQBg5R/4DD03ieGm6v6Hpv9nIAh98GwgYg1KrztcINC1s4o7/hg==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.0.9.tgz",
+      "integrity": "sha512-0K+8GvtwI7VkGmmInPydM2XZyBfIqLIbfR7mDQ+oPiz8mIinuHbV6sxOLdvX1Jv/myk7XTK9orgt3tuEpBu/zg==",
       "peer": true,
       "dependencies": {
-        "@smithy/types": "^2.7.0"
+        "@smithy/types": "^2.8.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.2.7.tgz",
-      "integrity": "sha512-0Qt5CuiogIuvQIfK+be7oVHcPsayLgfLJGkPlbgdbl0lD28nUKu4p11L+UG3SAEsqc9UsazO+nErPXw7+IgDpQ==",
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.2.8.tgz",
+      "integrity": "sha512-E62byatbwSWrtq9RJ7xN40tqrRKDGrEL4EluyNpaIDvfvet06a/QC58oHw2FgVaEgkj0tXZPjZaKrhPfpoU0qw==",
       "peer": true,
       "dependencies": {
-        "@smithy/types": "^2.7.0",
+        "@smithy/types": "^2.8.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2364,16 +2366,16 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "2.0.18",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.0.18.tgz",
-      "integrity": "sha512-SJRAj9jT/l9ocm8D0GojMbnA1sp7I4JeStOQ4lEXI8A5eHE73vbjlzlqIFB7cLvIgau0oUl4cGVpF9IGCrvjlw==",
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.0.19.tgz",
+      "integrity": "sha512-nwc3JihdM+kcJjtORv/n7qRHN2Kfh7S2RJI2qr8pz9UcY5TD8rSCRGQ0g81HgyS3jZ5X9U/L4p014P3FonBPhg==",
       "peer": true,
       "dependencies": {
-        "@smithy/eventstream-codec": "^2.0.15",
+        "@smithy/eventstream-codec": "^2.0.16",
         "@smithy/is-array-buffer": "^2.0.0",
-        "@smithy/types": "^2.7.0",
+        "@smithy/types": "^2.8.0",
         "@smithy/util-hex-encoding": "^2.0.0",
-        "@smithy/util-middleware": "^2.0.8",
+        "@smithy/util-middleware": "^2.0.9",
         "@smithy/util-uri-escape": "^2.0.0",
         "@smithy/util-utf8": "^2.0.2",
         "tslib": "^2.5.0"
@@ -2383,16 +2385,16 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.2.0.tgz",
-      "integrity": "sha512-C/bkNue5H5Obgl83SnlBt4v6VM68CqIjIELh3vAabud87xFYznLNKtj6Qb69Z+QOnLp9T+We++sEem/f2AHE+Q==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.2.1.tgz",
+      "integrity": "sha512-SpD7FLK92XV2fon2hMotaNDa2w5VAy5/uVjP9WFmjGSgWM8pTPVkHcDl1yFs5Z8LYbij0FSz+DbCBK6i+uXXUA==",
       "peer": true,
       "dependencies": {
-        "@smithy/middleware-endpoint": "^2.2.3",
-        "@smithy/middleware-stack": "^2.0.9",
-        "@smithy/protocol-http": "^3.0.11",
-        "@smithy/types": "^2.7.0",
-        "@smithy/util-stream": "^2.0.23",
+        "@smithy/middleware-endpoint": "^2.3.0",
+        "@smithy/middleware-stack": "^2.0.10",
+        "@smithy/protocol-http": "^3.0.12",
+        "@smithy/types": "^2.8.0",
+        "@smithy/util-stream": "^2.0.24",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2400,9 +2402,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.7.0.tgz",
-      "integrity": "sha512-1OIFyhK+vOkMbu4aN2HZz/MomREkrAC/HqY5mlJMUJfGrPRwijJDTeiN8Rnj9zUaB8ogXAfIOtZrrgqZ4w7Wnw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.8.0.tgz",
+      "integrity": "sha512-h9sz24cFgt/W1Re22OlhQKmUZkNh244ApgRsUDYinqF8R+QgcsBIX344u2j61TPshsTz3CvL6HYU1DnQdsSrHA==",
       "peer": true,
       "dependencies": {
         "tslib": "^2.5.0"
@@ -2412,13 +2414,13 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.15.tgz",
-      "integrity": "sha512-sADUncUj9rNbOTrdDGm4EXlUs0eQ9dyEo+V74PJoULY4jSQxS+9gwEgsPYyiu8PUOv16JC/MpHonOgqP/IEDZA==",
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.16.tgz",
+      "integrity": "sha512-Wfz5WqAoRT91TjRy1JeLR0fXtkIXHGsMbgzKFTx7E68SrZ55TB8xoG+vm11Ru4gheFTMXjAjwAxv1jQdC+pAQA==",
       "peer": true,
       "dependencies": {
-        "@smithy/querystring-parser": "^2.0.15",
-        "@smithy/types": "^2.7.0",
+        "@smithy/querystring-parser": "^2.0.16",
+        "@smithy/types": "^2.8.0",
         "tslib": "^2.5.0"
       }
     },
@@ -2482,14 +2484,14 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "2.0.23",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.23.tgz",
-      "integrity": "sha512-2u+7t7Wgz1jlfsf6il3pz6DIzyJHS3qrnNnmATICm00pQeqp2D4kUOYauOgKGIeKgVpwzzq8+hFQe749r3xR5w==",
+      "version": "2.0.24",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.24.tgz",
+      "integrity": "sha512-TsP5mBuLgO2C21+laNG2nHYZEyUdkbGURv2tHvSuQQxLz952MegX95uwdxOY2jR2H4GoKuVRfdJq7w4eIjGYeg==",
       "peer": true,
       "dependencies": {
-        "@smithy/property-provider": "^2.0.16",
-        "@smithy/smithy-client": "^2.2.0",
-        "@smithy/types": "^2.7.0",
+        "@smithy/property-provider": "^2.0.17",
+        "@smithy/smithy-client": "^2.2.1",
+        "@smithy/types": "^2.8.0",
         "bowser": "^2.11.0",
         "tslib": "^2.5.0"
       },
@@ -2498,17 +2500,17 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "2.0.31",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.31.tgz",
-      "integrity": "sha512-ZwdjAJAFkkQQ4hdE8HOcxFAWC3GPFXQ3yQ8IBwHH5nQBlr9q+p5eRQ7Y8iRRORJe4vksR+NASRXZ+E81Us1aXQ==",
+      "version": "2.0.32",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.32.tgz",
+      "integrity": "sha512-d0S33dXA2cq1NyorVMroMrEtqKMr3MlyLITcfTBf9pXiigYiPMOtbSI7czHIfDbuVuM89Cg0urAgpt73QV9mPQ==",
       "peer": true,
       "dependencies": {
-        "@smithy/config-resolver": "^2.0.22",
-        "@smithy/credential-provider-imds": "^2.1.4",
-        "@smithy/node-config-provider": "^2.1.8",
-        "@smithy/property-provider": "^2.0.16",
-        "@smithy/smithy-client": "^2.2.0",
-        "@smithy/types": "^2.7.0",
+        "@smithy/config-resolver": "^2.0.23",
+        "@smithy/credential-provider-imds": "^2.1.5",
+        "@smithy/node-config-provider": "^2.1.9",
+        "@smithy/property-provider": "^2.0.17",
+        "@smithy/smithy-client": "^2.2.1",
+        "@smithy/types": "^2.8.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2516,13 +2518,13 @@
       }
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-1.0.7.tgz",
-      "integrity": "sha512-Q2gEind3jxoLk6hdKWyESMU7LnXz8aamVwM+VeVjOYzYT1PalGlY/ETa48hv2YpV4+YV604y93YngyzzzQ4IIA==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-1.0.8.tgz",
+      "integrity": "sha512-l8zVuyZZ61IzZBYp5NWvsAhbaAjYkt0xg9R4xUASkg5SEeTT2meHOJwJHctKMFUXe4QZbn9fR2MaBYjP2119+w==",
       "peer": true,
       "dependencies": {
-        "@smithy/node-config-provider": "^2.1.8",
-        "@smithy/types": "^2.7.0",
+        "@smithy/node-config-provider": "^2.1.9",
+        "@smithy/types": "^2.8.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2542,12 +2544,12 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.0.8.tgz",
-      "integrity": "sha512-qkvqQjM8fRGGA8P2ydWylMhenCDP8VlkPn8kiNuFEaFz9xnUKC2irfqsBSJrfrOB9Qt6pQsI58r3zvvumhFMkw==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.0.9.tgz",
+      "integrity": "sha512-PnCnBJ07noMX1lMDTEefmxSlusWJUiLfrme++MfK5TD0xz8NYmakgoXy5zkF/16zKGmiwOeKAztWT/Vjk1KRIQ==",
       "peer": true,
       "dependencies": {
-        "@smithy/types": "^2.7.0",
+        "@smithy/types": "^2.8.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2555,13 +2557,13 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.0.8.tgz",
-      "integrity": "sha512-cQTPnVaVFMjjS6cb44WV2yXtHVyXDC5icKyIbejMarJEApYeJWpBU3LINTxHqp/tyLI+MZOUdosr2mZ3sdziNg==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.0.9.tgz",
+      "integrity": "sha512-46BFWe9RqB6g7f4mxm3W3HlqknqQQmWHKlhoqSFZuGNuiDU5KqmpebMbvC3tjTlUkqn4xa2Z7s3Hwb0HNs5scw==",
       "peer": true,
       "dependencies": {
-        "@smithy/service-error-classification": "^2.0.8",
-        "@smithy/types": "^2.7.0",
+        "@smithy/service-error-classification": "^2.0.9",
+        "@smithy/types": "^2.8.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2569,14 +2571,14 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "2.0.23",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.23.tgz",
-      "integrity": "sha512-OJMWq99LAZJUzUwTk+00plyxX3ESktBaGPhqNIEVab+53gLULiWN9B/8bRABLg0K6R6Xg4t80uRdhk3B/LZqMQ==",
+      "version": "2.0.24",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.24.tgz",
+      "integrity": "sha512-hRpbcRrOxDriMVmbya+Mv77VZVupxRAsfxVDKS54XuiURhdiwCUXJP0X1iJhHinuUf6n8pBF0MkG9C8VooMnWw==",
       "peer": true,
       "dependencies": {
-        "@smithy/fetch-http-handler": "^2.3.1",
-        "@smithy/node-http-handler": "^2.2.1",
-        "@smithy/types": "^2.7.0",
+        "@smithy/fetch-http-handler": "^2.3.2",
+        "@smithy/node-http-handler": "^2.2.2",
+        "@smithy/types": "^2.8.0",
         "@smithy/util-base64": "^2.0.1",
         "@smithy/util-buffer-from": "^2.0.0",
         "@smithy/util-hex-encoding": "^2.0.0",
@@ -2637,9 +2639,9 @@
       "dev": true
     },
     "node_modules/@types/aws-lambda": {
-      "version": "8.10.130",
-      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.130.tgz",
-      "integrity": "sha512-HxTfLeGvD1wTJqIGwcBCpNmHKenja+We1e0cuzeIDFfbEj3ixnlTInyPR/81zAe0Ss/Ip12rFK6XNeMLVucOSg==",
+      "version": "8.10.131",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.131.tgz",
+      "integrity": "sha512-IWmFpqnVDvskYWnNSiu/qlRn80XlIOU0Gy5rKCl/NjhnI95pV8qIHs6L5b+bpHhyzuOSzjLgBcwgFSXrC1nZWA==",
       "dev": true
     },
     "node_modules/@types/babel__core": {
@@ -2727,9 +2729,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.9.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.0.tgz",
-      "integrity": "sha512-nekiGu2NDb1BcVofVcEKMIwzlx4NjHlcjhoxxKBNLtz15Y1z7MYf549DFvkHSId02Ax6kGwWntIBPC3l/JZcmw==",
+      "version": "20.11.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.0.tgz",
+      "integrity": "sha512-o9bjXmDNcF7GbM4CNQpmi+TutCgap/K3w1JyKgxAjqx41zp9qlIAVFi0IhCNsJcXolEqLWhbFbEeL0PvYm4pcQ==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -2778,9 +2780,9 @@
       }
     },
     "node_modules/acorn-walk": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.1.tgz",
-      "integrity": "sha512-TgUZgYvqZprrl7YldZNoa9OciCAyZR+Ejm9eXzKCmjsF5IKp/wgQ7Z/ZpjpGTIUPwrHQIcYeI8qDh4PsEwxMbw==",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
+      "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
@@ -2854,9 +2856,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.108.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.108.0.tgz",
-      "integrity": "sha512-qpBAtEGudaO7EVuGfur+lIpoh+JeWVgnvQ7z8MBtr7LEzolQf/9Cebovx/+KCUI3VnK/jsL/+3ixYwraaT/y2A==",
+      "version": "2.119.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.119.0.tgz",
+      "integrity": "sha512-5+cCX2TzZLiistzFMKxcWQEc0MRkE+48sOkWdfN/8qJ5jnmZs4RpWTVU1HtkQKwEbBsz9jACpRFpkbu7S2Uitg==",
       "dev": true,
       "bin": {
         "cdk": "bin/cdk"
@@ -2869,9 +2871,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.117.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.117.0.tgz",
-      "integrity": "sha512-My5T4hn34H6+tnZxKK2VlcvGI2N5SjqGt9lXWADcahdobuUcNizYrls7h/vcQ3BfwcZ5/tHTKtivkNyL8I1LDg==",
+      "version": "2.119.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.119.0.tgz",
+      "integrity": "sha512-aq1CFM4KkgJ0tkXCvkeCd2ThFxbaJCY5GVzG5X9SajSKEng7i4mmtblTRLfkz2lwhJLcoHXrvD0Nmf8kcNP5fg==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -3461,9 +3463,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001572",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001572.tgz",
-      "integrity": "sha512-1Pbh5FLmn5y4+QhNyJE9j3/7dK44dGB83/ZMjv/qJk86TvDbjk0LosiZo0i0WB0Vx607qMX9jYrn1VLHCkN4rw==",
+      "version": "1.0.30001576",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001576.tgz",
+      "integrity": "sha512-ff5BdakGe2P3SQsMsiqmt1Lc8221NR1VzHj5jXN5vBny9A6fpze94HiVV/n7XRosOlsShJcvMv5mdnpjOGCEgg==",
       "dev": true,
       "funding": [
         {
@@ -3713,9 +3715,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.616",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.616.tgz",
-      "integrity": "sha512-1n7zWYh8eS0L9Uy+GskE0lkBUNK83cXTVJI0pU3mGprFsbfSdAc15VTFbo+A+Bq4pwstmL30AVcEU3Fo463lNg==",
+      "version": "1.4.629",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.629.tgz",
+      "integrity": "sha512-5UUkr3k3CZ/k+9Sw7vaaIMyOzMC0XbPyprKI3n0tbKDqkzTDOjK4izm7DxlkueRMim6ZZQ1ja9F7hoFVplHihA==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -5858,9 +5860,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -5945,9 +5947,9 @@
       }
     },
     "node_modules/web-streams-polyfill": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
-      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.2.tgz",
+      "integrity": "sha512-3pRGuxRF5gpuZc0W+EpwQRmCD7gRqcDOMt688KmdlDAgAyaB1XlN0zq2njfDNm44XVdIouE7pZ6GzbdyH47uIQ==",
       "peer": true,
       "engines": {
         "node": ">= 8"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@types/jest": "^29.5.11",
         "@types/node": "^20.11.0",
         "@types/source-map-support": "^0.5.10",
-        "aws-cdk": "^2.120.0",
+        "aws-cdk": "^2.121.1",
         "esbuild": "^0.19.11",
         "jest": "^29.7.0",
         "prettier": "^3.1.1",
@@ -23,7 +23,7 @@
       },
       "peerDependencies": {
         "@aws-sdk/client-secrets-manager": "^3.462.0",
-        "aws-cdk-lib": "^2.120.0",
+        "aws-cdk-lib": "^2.121.0",
         "constructs": "^10.0.0",
         "node-fetch": "^3.3.2",
         "source-map-support": "^0.5.21"
@@ -2856,9 +2856,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.120.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.120.0.tgz",
-      "integrity": "sha512-1kAxwMELEaFTIYIhB69DhaqBydujAPrQvZjngWQeV9Nt+AsiWzwmtGncql7u0oroyDrJEjdneGgqp2HjIiL1ZQ==",
+      "version": "2.121.1",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.121.1.tgz",
+      "integrity": "sha512-T8UFuNGDnXNmcHagCGeQ8xQA3zU/o2ENuyGXO/ho+U3KyYs7tnWIr++ovrp2FvhiBpmBv6SuKiueBA6OW7utBw==",
       "dev": true,
       "bin": {
         "cdk": "bin/cdk"
@@ -2871,9 +2871,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.120.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.120.0.tgz",
-      "integrity": "sha512-EOcbN4I33NS+1z8YnOfUQ7QzuSj4Hjr3p/PTwsQH962fE/EEGyeHAGCL8TLEQMZfFfKVnvPwi3eD5TJXooOU7w==",
+      "version": "2.121.1",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.121.1.tgz",
+      "integrity": "sha512-wrOHDDQqVuH2tRTH7p2LaMPVI3V2bqr8X//Qrhy+hOFA04u2MVetQYev+NgMXPjNzU9IGX2wy1Fs9Y/ntq2sQA==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@types/jest": "^29.5.11",
     "@types/node": "^20.11.0",
     "@types/source-map-support": "^0.5.10",
-    "aws-cdk": "^2.119.0",
+    "aws-cdk": "^2.120.0",
     "esbuild": "^0.19.11",
     "jest": "^29.7.0",
     "prettier": "^3.1.1",
@@ -37,7 +37,7 @@
   },
   "peerDependencies": {
     "@aws-sdk/client-secrets-manager": "^3.462.0",
-    "aws-cdk-lib": "^2.113.0",
+    "aws-cdk-lib": "^2.120.0",
     "constructs": "^10.0.0",
     "node-fetch": "^3.3.2",
     "source-map-support": "^0.5.21"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@restatedev/restate-cdk",
   "description": "Restate.dev CDK constructs",
-  "version": "0.4.2",
+  "version": "0.7.0",
   "author": "Restate Developers",
   "license": "MIT",
   "email": "code@restate.dev",
@@ -23,17 +23,17 @@
     "cdk": "cdk"
   },
   "devDependencies": {
-    "@types/aws-lambda": "^8.10.126",
-    "@types/jest": "^29.5.8",
-    "@types/node": "20.9.0",
+    "@types/aws-lambda": "^8.10.131",
+    "@types/jest": "^29.5.11",
+    "@types/node": "^20.11.0",
     "@types/source-map-support": "^0.5.10",
-    "aws-cdk": "2.108.0",
-    "esbuild": "^0.19.6",
+    "aws-cdk": "^2.119.0",
+    "esbuild": "^0.19.11",
     "jest": "^29.7.0",
-    "prettier": "^3.1.0",
+    "prettier": "^3.1.1",
     "ts-jest": "^29.1.1",
-    "ts-node": "^10.9.1",
-    "typescript": "~5.2.2"
+    "ts-node": "^10.9.2",
+    "typescript": "^5.3.3"
   },
   "peerDependencies": {
     "@aws-sdk/client-secrets-manager": "^3.462.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@types/jest": "^29.5.11",
     "@types/node": "^20.11.0",
     "@types/source-map-support": "^0.5.10",
-    "aws-cdk": "^2.120.0",
+    "aws-cdk": "^2.121.1",
     "esbuild": "^0.19.11",
     "jest": "^29.7.0",
     "prettier": "^3.1.1",
@@ -37,7 +37,7 @@
   },
   "peerDependencies": {
     "@aws-sdk/client-secrets-manager": "^3.462.0",
-    "aws-cdk-lib": "^2.120.0",
+    "aws-cdk-lib": "^2.121.0",
     "constructs": "^10.0.0",
     "node-fetch": "^3.3.2",
     "source-map-support": "^0.5.21"


### PR DESCRIPTION
To do before merge:

- [x] Rename `/endpoints` to `/deployments` to ensure we're compatible with the latest release

✅ Tested single-node deployment construct with `ghcr.io/restatedev/restate`