### PR TITLE
Add Fargate Restate deployment construct

### DIFF
--- a/lib/restate-constructs/deployments-common.ts
+++ b/lib/restate-constructs/deployments-common.ts
@@ -1,0 +1,4 @@
+export enum TracingMode {
+  DISABLED = "DISABLED",
+  AWS_XRAY = "AWS_XRAY",
+}

--- a/lib/restate-constructs/fargate-restate-deployment.ts
+++ b/lib/restate-constructs/fargate-restate-deployment.ts
@@ -1,0 +1,311 @@
+/*
+ * Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
+
+import { Construct } from "constructs";
+import * as cdk from "aws-cdk-lib";
+import * as acm from "aws-cdk-lib/aws-certificatemanager";
+import * as logs from "aws-cdk-lib/aws-logs";
+import * as ec2 from "aws-cdk-lib/aws-ec2";
+import * as iam from "aws-cdk-lib/aws-iam";
+import * as ecs from "aws-cdk-lib/aws-ecs";
+import * as efs from "aws-cdk-lib/aws-efs";
+import * as elb2 from "aws-cdk-lib/aws-elasticloadbalancingv2";
+import * as r53 from "aws-cdk-lib/aws-route53";
+import * as targets from "aws-cdk-lib/aws-route53-targets";
+import { IRestateEnvironment } from "./restate-environment";
+import { TracingMode } from "./deployments-common";
+
+const PUBLIC_INGRESS_PORT = 443;
+const PUBLIC_ADMIN_PORT = 9073;
+const RESTATE_INGRESS_PORT = 8080;
+const RESTATE_ADMIN_PORT = 9070;
+const RESTATE_IMAGE_DEFAULT = "docker.io/restatedev/restate";
+const RESTATE_DOCKER_DEFAULT_TAG = "latest";
+const ADOT_DOCKER_DEFAULT_TAG = "latest";
+
+export interface RestateFargateProps {
+  /** The VPC in which to launch the Restate host. */
+  vpc?: ec2.IVpc;
+
+  /** Log group for Restate service logs. */
+  logGroup?: logs.LogGroup;
+
+  /** Tracing mode for Restate services. Defaults to {@link TracingMode.DISABLED}. */
+  tracing?: TracingMode;
+
+  /** Prefix for resources created by this construct that require unique names. */
+  prefix?: string;
+
+  /** ECS cluster name. */
+  clusterName?: string;
+
+  /** Restate Docker image name. Defaults to `latest`. */
+  restateImage?: string;
+
+  /** Restate Docker image tag. Defaults to `latest`. */
+  restateTag?: string;
+
+  /** Amazon Distro for Open Telemetry Docker image tag. Defaults to `latest`. */
+  adotTag?: string;
+
+  /**
+   * Environment for Restate container. Use it to configure logging and other process-level settings.
+   */
+  environment?: Record<string, string>;
+
+  /**
+   * Restate container extra arguments.
+   */
+  command?: string[];
+
+  /**
+   * The full name for the public endpoint.
+   */
+  dnsName: string;
+
+  /**
+   * DNS zone in which to create the public endpoint.
+   */
+  hostedZone: r53.IHostedZone;
+
+  /**
+   * Removal policy for long-lived resources (storage, logs). Default: `cdk.RemovalPolicy.DESTROY`.
+   */
+  removalPolicy?: cdk.RemovalPolicy;
+
+  /**
+   * Load balancer configuration.
+   */
+  loadBalancer?: {
+    /** @see BaseLoadBalancerProps.internetFacing */
+    internetFacing?: boolean;
+
+    /**
+     * If you set this to false, you can customize the access to the pair of ALB listeners via
+     * {@link FargateRestateDeployment.ingressListener} and {@link FargateRestateDeployment.adminListener}.
+     *
+     * @see BaseApplicationListenerProps.open */
+    open?: boolean;
+  };
+}
+
+/**
+ * Creates a Restate service deployment running as a Fargate task and backed by EFS.,
+ */
+export class FargateRestateDeployment extends Construct implements IRestateEnvironment {
+  readonly invokerRole: iam.IRole;
+  readonly vpc: ec2.IVpc;
+
+  readonly ingressUrl: string;
+  readonly adminUrl: string;
+  readonly securityGroup: ec2.SecurityGroup;
+  readonly dataStore: efs.FileSystem;
+  readonly ingressListener: elb2.ApplicationListener;
+  readonly adminListener: elb2.ApplicationListener;
+
+  constructor(scope: Construct, id: string, props: RestateFargateProps) {
+    super(scope, id);
+
+    this.vpc = props.vpc ?? ec2.Vpc.fromLookup(this, "Vpc", { isDefault: true });
+
+    const restateImage = props.restateImage ?? RESTATE_IMAGE_DEFAULT;
+    const restateTag = props.restateTag ?? RESTATE_DOCKER_DEFAULT_TAG;
+    const adotTag = props.adotTag ?? ADOT_DOCKER_DEFAULT_TAG; // TODO: add X-Ray support like we have for EC2
+
+    const fs = new efs.FileSystem(this, "DataStore", {
+      vpc: this.vpc,
+      lifecyclePolicy: efs.LifecyclePolicy.AFTER_30_DAYS,
+      performanceMode: efs.PerformanceMode.GENERAL_PURPOSE,
+      throughputMode: efs.ThroughputMode.BURSTING,
+      removalPolicy: props.removalPolicy ?? cdk.RemovalPolicy.DESTROY,
+    });
+    fs.addToResourcePolicy(
+      new iam.PolicyStatement({
+        sid: "AllowEfsMount",
+        actions: ["elasticfilesystem:ClientMount"],
+        // Restricting to the ECS execution role does not work; probably doesn't matter - EFS access is secured by a security group
+        principals: [new iam.AnyPrincipal()],
+        conditions: {
+          Bool: {
+            "elasticfilesystem:AccessedViaMountTarget": "true",
+          },
+        },
+      }),
+    );
+    this.dataStore = fs;
+
+    const cluster = new ecs.Cluster(this, "Cluster", {
+      vpc: this.vpc,
+      clusterName: props.clusterName,
+    });
+
+    const restateTask = new ecs.FargateTaskDefinition(this, "RestateTask", {
+      cpu: 4096,
+      memoryLimitMiB: 8192,
+      runtimePlatform: {
+        cpuArchitecture: ecs.CpuArchitecture.ARM64,
+        operatingSystemFamily: ecs.OperatingSystemFamily.LINUX,
+      },
+      volumes: [
+        {
+          name: "restateStore",
+          efsVolumeConfiguration: {
+            fileSystemId: fs.fileSystemId,
+            authorizationConfig: {},
+          },
+        },
+      ],
+    });
+
+    // TODO: Start an ADOT container and hook it up to Restate and AWS X-Ray or another OTel sink
+    // if (props.tracing === TracingMode.AWS_XRAY) {
+    //   restateTask.taskRole.addManagedPolicy(iam.ManagedPolicy.fromAwsManagedPolicyName("AWSXrayWriteOnlyAccess"));
+    // }
+
+    new iam.Policy(this, "TaskPolicy", {
+      statements: [
+        new iam.PolicyStatement({
+          sid: "AllowAssumeAnyRole",
+          actions: ["sts:AssumeRole"],
+          resources: ["*"], // we don't know upfront what invoker roles we may be asked to assume at runtime
+        }),
+      ],
+    }).attachToRole(restateTask.taskRole);
+
+    const invokerRole = new iam.Role(this, "InvokerRole", {
+      assumedBy: new iam.ArnPrincipal(restateTask.taskRole.roleArn),
+      description: "Assumed by Restate deployment to invoke Lambda-based services",
+    });
+    invokerRole.grantAssumeRole(restateTask.taskRole);
+    this.invokerRole = invokerRole;
+
+    const logGroup =
+      props.logGroup ??
+      new logs.LogGroup(this, "Logs", {
+        logGroupName: `/restate/${id}`,
+        removalPolicy: props.removalPolicy ?? cdk.RemovalPolicy.DESTROY,
+      });
+
+    const restate = restateTask.addContainer("Restate", {
+      containerName: "restate-runtime",
+      image: ecs.ContainerImage.fromRegistry(`${restateImage}:${restateTag}`),
+      portMappings: [{ containerPort: RESTATE_INGRESS_PORT }, { containerPort: RESTATE_ADMIN_PORT }],
+      logging: ecs.LogDriver.awsLogs({
+        logGroup,
+        streamPrefix: "restate",
+      }),
+      environment: {
+        RESTATE_OBSERVABILITY__LOG__FORMAT: "Json",
+        // RUST_LOG: "warn,restate=info",
+      },
+      command: props.command,
+      startTimeout: cdk.Duration.seconds(20),
+      stopTimeout: cdk.Duration.seconds(20),
+    });
+    restate.addMountPoints({
+      containerPath: "/target",
+      readOnly: false,
+      sourceVolume: "restateStore",
+    });
+
+    const restateSecurityGroup = new ec2.SecurityGroup(this, "SecurityGroup", {
+      vpc: this.vpc,
+      allowAllOutbound: true,
+    });
+    this.securityGroup = restateSecurityGroup;
+
+    const restateFargateService = new ecs.FargateService(this, "Service", {
+      cluster,
+      taskDefinition: restateTask,
+      assignPublicIp: true,
+      circuitBreaker: {
+        enable: true,
+        rollback: true,
+      },
+      minHealthyPercent: 0, // allow scale down to zero during deployments (required for at-most-1 max setting)
+      maxHealthyPercent: 100, // don't start more than one copy
+      securityGroups: [restateSecurityGroup],
+    });
+
+    fs.connections.allowDefaultPortFrom(restateSecurityGroup);
+    fs.connections.allowDefaultPortTo(restateSecurityGroup);
+    fs.grantRootAccess(restateFargateService.taskDefinition.taskRole.grantPrincipal);
+
+    const alb = new elb2.ApplicationLoadBalancer(this, "Alb", {
+      vpc: this.vpc,
+      internetFacing: props.loadBalancer?.internetFacing,
+    });
+
+    const publicApiCertificate = new acm.Certificate(this, "Certificate", {
+      domainName: props.dnsName,
+      validation: acm.CertificateValidation.fromDns(props.hostedZone),
+    });
+
+    const ingressListener = alb.addListener("IngressListener", {
+      port: PUBLIC_INGRESS_PORT,
+      protocol: elb2.ApplicationProtocol.HTTPS,
+      certificates: [publicApiCertificate],
+      open: props.loadBalancer?.open,
+    });
+    ingressListener.addTargets("FargateIngressTarget", {
+      targets: [
+        restateFargateService.loadBalancerTarget({
+          containerName: restate.containerName,
+          containerPort: RESTATE_INGRESS_PORT,
+        }),
+      ],
+      protocol: elb2.ApplicationProtocol.HTTP,
+      healthCheck: {
+        path: "/grpc.health.v1.Health/Check",
+        interval: cdk.Duration.seconds(5),
+        healthyThresholdCount: 3,
+        unhealthyThresholdCount: 3,
+        timeout: cdk.Duration.seconds(2),
+      },
+      deregistrationDelay: cdk.Duration.seconds(5),
+    });
+    this.ingressListener = ingressListener;
+
+    const adminListener = alb.addListener("AdminListener", {
+      port: PUBLIC_ADMIN_PORT,
+      protocol: elb2.ApplicationProtocol.HTTPS,
+      certificates: [publicApiCertificate],
+    });
+    adminListener.addTargets("FargateAdminTarget", {
+      targets: [
+        restateFargateService.loadBalancerTarget({
+          containerName: restate.containerName,
+          containerPort: RESTATE_ADMIN_PORT,
+        }),
+      ],
+      protocol: elb2.ApplicationProtocol.HTTP,
+      healthCheck: {
+        path: "/health",
+        interval: cdk.Duration.seconds(5),
+        healthyThresholdCount: 3,
+        unhealthyThresholdCount: 3,
+        timeout: cdk.Duration.seconds(2),
+      },
+      deregistrationDelay: cdk.Duration.seconds(5),
+    });
+    this.adminListener = adminListener;
+
+    new r53.ARecord(this, "AlbAlias", {
+      zone: props.hostedZone,
+      recordName: props.dnsName.split(".")[0],
+      target: r53.RecordTarget.fromAlias(new targets.LoadBalancerTarget(alb)),
+      // other ARecord configuration...
+    });
+
+    this.ingressUrl = `https://${props.dnsName}${PUBLIC_INGRESS_PORT == 443 ? "" : `:${PUBLIC_INGRESS_PORT}`}`;
+    this.adminUrl = `https://${props.dnsName}:${PUBLIC_ADMIN_PORT}`;
+  }
+}

--- a/lib/restate-constructs/index.ts
+++ b/lib/restate-constructs/index.ts
@@ -11,4 +11,6 @@
 
 export * from "./service-deployer";
 export * from "./restate-environment";
+export * from "./deployments-common";
 export * from "./single-node-restate-deployment";
+export * from "./fargate-restate-deployment";

--- a/test/__snapshots__/restate-constructs.test.ts.snap
+++ b/test/__snapshots__/restate-constructs.test.ts.snap
@@ -1,5 +1,694 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Restate constructs Create a self-hosted Restate environment deployed on EC2 1`] = `
+"Resources:
+  RestateInstanceRoleACC59A6F:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: 'sts:AssumeRole'
+            Effect: Allow
+            Principal:
+              Service: ec2.amazonaws.com
+        Version: '2012-10-17'
+      ManagedPolicyArns:
+        - 'Fn::Join':
+            - ''
+            - - 'arn:'
+              - Ref: 'AWS::Partition'
+              - ':iam::aws:policy/AmazonSSMManagedInstanceCore'
+  RestateInstanceRoleDefaultPolicyD1D39538:
+    Type: 'AWS::IAM::Policy'
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action:
+              - 'logs:CreateLogStream'
+              - 'logs:PutLogEvents'
+            Effect: Allow
+            Resource:
+              'Fn::GetAtt':
+                - RestateLogsFD86ECAE
+                - Arn
+        Version: '2012-10-17'
+      PolicyName: RestateInstanceRoleDefaultPolicyD1D39538
+      Roles:
+        - Ref: RestateInstanceRoleACC59A6F
+  RestateLogsFD86ECAE:
+    Type: 'AWS::Logs::LogGroup'
+    Properties:
+      RetentionInDays: 731
+    UpdateReplacePolicy: Retain
+    DeletionPolicy: Retain
+  RestateHostInstanceSecurityGroup471D630B:
+    Type: 'AWS::EC2::SecurityGroup'
+    Properties:
+      GroupDescription: RestateOnFargateStack/Restate/Host/InstanceSecurityGroup
+      SecurityGroupEgress:
+        - CidrIp: 0.0.0.0/0
+          Description: Allow all outbound traffic by default
+          IpProtocol: '-1'
+      Tags:
+        - Key: Name
+          Value: RestateOnFargateStack/Restate/Host
+      VpcId: vpc-12345
+  RestateHostInstanceProfile14AE3AC8:
+    Type: 'AWS::IAM::InstanceProfile'
+    Properties:
+      Roles:
+        - Ref: RestateInstanceRoleACC59A6F
+  RestateHost1AC4F9D1:
+    Type: 'AWS::EC2::Instance'
+    Properties:
+      AvailabilityZone: dummy1a
+      IamInstanceProfile:
+        Ref: RestateHostInstanceProfile14AE3AC8
+      ImageId:
+        Ref: >-
+          SsmParameterValueawsserviceamiamazonlinuxlatestal2023amikernel61arm64C96584B6F00A464EAD1953AFF4B05118Parameter
+      InstanceType: t4g.micro
+      SecurityGroupIds:
+        - 'Fn::GetAtt':
+            - RestateHostInstanceSecurityGroup471D630B
+            - GroupId
+        - 'Fn::GetAtt':
+            - RestateRestateSecurityGroup73273B13
+            - GroupId
+      SubnetId: s-12345
+      Tags:
+        - Key: Name
+          Value: RestateOnFargateStack/Restate/Host
+      UserData:
+        'Fn::Base64':
+          'Fn::Join':
+            - ''
+            - - >-
+                #!/bin/bash
+
+                yum update -y
+
+                yum install -y docker nginx
+
+                systemctl enable docker.service
+
+                systemctl start docker.service
+
+                docker run --name adot --restart unless-stopped --detach -p
+                4317:4317 -p 55680:55680 -p 8889:8888
+                public.ecr.aws/aws-observability/aws-otel-collector:latest
+
+                docker run --name restate --restart unless-stopped --detach
+                --volume /var/restate:/target --network=host -e
+                RESTATE_OBSERVABILITY__LOG__FORMAT=Json -e
+                RUST_LOG=info,restate_worker::partition=warn -e
+                RESTATE_OBSERVABILITY__TRACING__ENDPOINT=http://localhost:4317
+                --log-driver=awslogs --log-opt awslogs-group=
+              - Ref: RestateLogsFD86ECAE
+              - >2-
+                 docker.io/restatedev/restate:latest
+                mkdir -p /etc/pki/private
+
+                openssl req -new -x509 -nodes -sha256 -days 365 -extensions
+                v3_ca -subj
+                '/C=DE/ST=Berlin/L=Berlin/O=restate.dev/OU=demo/CN=restate.example.com'
+                -newkey rsa:2048 -keyout /etc/pki/private/restate-selfsigned.key
+                -out /etc/pki/private/restate-selfsigned.crt
+
+                cat << EOF > /etc/nginx/conf.d/restate-ingress.conf
+
+                server {
+                  listen 443 ssl http2;
+                  listen [::]:443 ssl http2;
+                  server_name _;
+                  root /usr/share/nginx/html;
+
+                  ssl_certificate "/etc/pki/private/restate-selfsigned.crt";
+                  ssl_certificate_key "/etc/pki/private/restate-selfsigned.key";
+                  ssl_session_cache shared:SSL:1m;
+                  ssl_session_timeout 10m;
+                  ssl_ciphers PROFILE=SYSTEM;
+                  ssl_prefer_server_ciphers on;
+
+                  location / {
+                    proxy_pass http://localhost:8080;
+                  }
+                }
+
+
+                server {
+                  listen 9073 ssl http2;
+                  listen [::]:9073 ssl http2;
+                  server_name _;
+                  root /usr/share/nginx/html;
+
+                  ssl_certificate "/etc/pki/private/restate-selfsigned.crt";
+                  ssl_certificate_key "/etc/pki/private/restate-selfsigned.key";
+                  ssl_session_cache shared:SSL:1m;
+                  ssl_session_timeout 10m;
+                  ssl_ciphers PROFILE=SYSTEM;
+                  ssl_prefer_server_ciphers on;
+
+                  location / {
+                    proxy_pass http://localhost:9070;
+                  }
+                }
+
+                EOF
+
+                systemctl enable nginx
+
+                systemctl start nginx
+    DependsOn:
+      - RestateInstanceRoleDefaultPolicyD1D39538
+      - RestateInstanceRoleACC59A6F
+  RestateRestateSecurityGroup73273B13:
+    Type: 'AWS::EC2::SecurityGroup'
+    Properties:
+      GroupDescription: Restate service ACLs
+      GroupName: RestateSecurityGroup
+      SecurityGroupEgress:
+        - CidrIp: 0.0.0.0/0
+          Description: Allow all outbound traffic by default
+          IpProtocol: '-1'
+      SecurityGroupIngress:
+        - CidrIp: 0.0.0.0/0
+          Description: Allow traffic from anywhere to Restate ingress port
+          FromPort: 443
+          IpProtocol: tcp
+          ToPort: 443
+        - CidrIp: 0.0.0.0/0
+          Description: Allow traffic from anywhere to Restate admin port
+          FromPort: 9073
+          IpProtocol: tcp
+          ToPort: 9073
+      VpcId: vpc-12345
+Parameters: Any<Object>
+"
+`;
+
+exports[`Restate constructs Create a self-hosted Restate environment deployed on ECS Fargate 1`] = `
+"Resources:
+  ZoneA5DE4B68:
+    Type: 'AWS::Route53::HostedZone'
+    Properties:
+      Name: example.com.
+  RestateRestateDataStoreC3956B97:
+    Type: 'AWS::EFS::FileSystem'
+    Properties:
+      Encrypted: true
+      FileSystemPolicy:
+        Statement:
+          - Action: 'elasticfilesystem:ClientMount'
+            Condition:
+              Bool:
+                'elasticfilesystem:AccessedViaMountTarget': 'true'
+            Effect: Allow
+            Principal:
+              AWS: '*'
+            Sid: AllowEfsMount
+          - Action:
+              - 'elasticfilesystem:ClientWrite'
+              - 'elasticfilesystem:ClientRootAccess'
+            Condition:
+              Bool:
+                'elasticfilesystem:AccessedViaMountTarget': 'true'
+            Effect: Allow
+            Principal:
+              AWS: '*'
+        Version: '2012-10-17'
+      FileSystemTags:
+        - Key: Name
+          Value: RestateOnFargateStack/Restate/RestateDataStore
+      LifecyclePolicies:
+        - TransitionToIA: AFTER_30_DAYS
+      PerformanceMode: generalPurpose
+      ThroughputMode: bursting
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Delete
+  RestateRestateDataStoreEfsSecurityGroupF2C75FD3:
+    Type: 'AWS::EC2::SecurityGroup'
+    Properties:
+      GroupDescription: RestateOnFargateStack/Restate/RestateDataStore/EfsSecurityGroup
+      SecurityGroupEgress:
+        - CidrIp: 0.0.0.0/0
+          Description: Allow all outbound traffic by default
+          IpProtocol: '-1'
+      Tags:
+        - Key: Name
+          Value: RestateOnFargateStack/Restate/RestateDataStore
+      VpcId: vpc-12345
+  RestateRestateDataStoreEfsSecurityGroupfromRestateOnFargateStackRestateRestateSecurityGroup7775CAEF2049AAF8D85F:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    Properties:
+      Description: 'from RestateOnFargateStackRestateRestateSecurityGroup7775CAEF:2049'
+      FromPort: 2049
+      GroupId:
+        'Fn::GetAtt':
+          - RestateRestateDataStoreEfsSecurityGroupF2C75FD3
+          - GroupId
+      IpProtocol: tcp
+      SourceSecurityGroupId:
+        'Fn::GetAtt':
+          - RestateRestateSecurityGroup73273B13
+          - GroupId
+      ToPort: 2049
+  RestateRestateDataStoreEfsMountTarget14FBF0C07:
+    Type: 'AWS::EFS::MountTarget'
+    Properties:
+      FileSystemId:
+        Ref: RestateRestateDataStoreC3956B97
+      SecurityGroups:
+        - 'Fn::GetAtt':
+            - RestateRestateDataStoreEfsSecurityGroupF2C75FD3
+            - GroupId
+      SubnetId: p-12345
+  RestateRestateDataStoreEfsMountTarget2E8E875FF:
+    Type: 'AWS::EFS::MountTarget'
+    Properties:
+      FileSystemId:
+        Ref: RestateRestateDataStoreC3956B97
+      SecurityGroups:
+        - 'Fn::GetAtt':
+            - RestateRestateDataStoreEfsSecurityGroupF2C75FD3
+            - GroupId
+      SubnetId: p-67890
+  RestateRestateClusterDED250CD:
+    Type: 'AWS::ECS::Cluster'
+  RestateRestateTaskTaskRole3425804E:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: 'sts:AssumeRole'
+            Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+        Version: '2012-10-17'
+  RestateRestateTaskTaskRoleDefaultPolicyD6897EE5:
+    Type: 'AWS::IAM::Policy'
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action: 'sts:AssumeRole'
+            Effect: Allow
+            Resource:
+              'Fn::GetAtt':
+                - RestateRestateInvokerRole74F38CCD
+                - Arn
+          - Action:
+              - 'elasticfilesystem:ClientMount'
+              - 'elasticfilesystem:ClientWrite'
+              - 'elasticfilesystem:ClientRootAccess'
+            Condition:
+              Bool:
+                'elasticfilesystem:AccessedViaMountTarget': 'true'
+            Effect: Allow
+            Resource:
+              'Fn::GetAtt':
+                - RestateRestateDataStoreC3956B97
+                - Arn
+        Version: '2012-10-17'
+      PolicyName: RestateRestateTaskTaskRoleDefaultPolicyD6897EE5
+      Roles:
+        - Ref: RestateRestateTaskTaskRole3425804E
+  RestateRestateTask73B141AE:
+    Type: 'AWS::ECS::TaskDefinition'
+    Properties:
+      ContainerDefinitions:
+        - Environment:
+            - Name: RESTATE_OBSERVABILITY__LOG__FORMAT
+              Value: Json
+          Essential: true
+          Image: 'ghcr.io/restatedev/restate:cloud2'
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group:
+                Ref: RestateRestateLogs6673AD28
+              awslogs-stream-prefix: restate
+              awslogs-region: region
+          MountPoints:
+            - ContainerPath: /target
+              ReadOnly: false
+              SourceVolume: restateStore
+          Name: restate-runtime
+          PortMappings:
+            - ContainerPort: 8080
+              Protocol: tcp
+            - ContainerPort: 9070
+              Protocol: tcp
+          StartTimeout: 20
+          StopTimeout: 20
+      Cpu: '4096'
+      ExecutionRoleArn:
+        'Fn::GetAtt':
+          - RestateRestateTaskExecutionRole8ED5B0F9
+          - Arn
+      Family: RestateOnFargateStackRestateRestateTaskD92D0B67
+      Memory: '8192'
+      NetworkMode: awsvpc
+      RequiresCompatibilities:
+        - FARGATE
+      RuntimePlatform:
+        CpuArchitecture: ARM64
+        OperatingSystemFamily: LINUX
+      TaskRoleArn:
+        'Fn::GetAtt':
+          - RestateRestateTaskTaskRole3425804E
+          - Arn
+      Volumes:
+        - EFSVolumeConfiguration:
+            AuthorizationConfig: {}
+            FilesystemId:
+              Ref: RestateRestateDataStoreC3956B97
+          Name: restateStore
+  RestateRestateTaskExecutionRole8ED5B0F9:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: 'sts:AssumeRole'
+            Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+        Version: '2012-10-17'
+  RestateRestateTaskExecutionRoleDefaultPolicy8E1BA931:
+    Type: 'AWS::IAM::Policy'
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action:
+              - 'logs:CreateLogStream'
+              - 'logs:PutLogEvents'
+            Effect: Allow
+            Resource:
+              'Fn::GetAtt':
+                - RestateRestateLogs6673AD28
+                - Arn
+        Version: '2012-10-17'
+      PolicyName: RestateRestateTaskExecutionRoleDefaultPolicy8E1BA931
+      Roles:
+        - Ref: RestateRestateTaskExecutionRole8ED5B0F9
+  RestateRestateTaskPolicyA238E9DD:
+    Type: 'AWS::IAM::Policy'
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action: 'sts:AssumeRole'
+            Effect: Allow
+            Resource: '*'
+            Sid: AllowAssumeAnyRole
+        Version: '2012-10-17'
+      PolicyName: RestateRestateTaskPolicyA238E9DD
+      Roles:
+        - Ref: RestateRestateTaskTaskRole3425804E
+  RestateRestateInvokerRole74F38CCD:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: 'sts:AssumeRole'
+            Effect: Allow
+            Principal:
+              AWS:
+                'Fn::Join':
+                  - ''
+                  - - 'arn:'
+                    - Ref: 'AWS::Partition'
+                    - ':iam::account-id:root'
+        Version: '2012-10-17'
+      Description: Assumed by Restate deployment to invoke Lambda-based services
+  RestateRestateLogs6673AD28:
+    Type: 'AWS::Logs::LogGroup'
+    Properties:
+      LogGroupName: /pavel/restate-fargate-test
+      RetentionInDays: 7
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Delete
+  RestateRestateSecurityGroup73273B13:
+    Type: 'AWS::EC2::SecurityGroup'
+    Properties:
+      GroupDescription: RestateOnFargateStack/Restate/RestateSecurityGroup
+      SecurityGroupEgress:
+        - CidrIp: 0.0.0.0/0
+          Description: Allow all outbound traffic by default
+          IpProtocol: '-1'
+      VpcId: vpc-12345
+  RestateRestateSecurityGroupfromRestateOnFargateStackRestateRestateDataStoreEfsSecurityGroupD2921C8A2049F2042747:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    Properties:
+      Description: >-
+        from
+        RestateOnFargateStackRestateRestateDataStoreEfsSecurityGroupD2921C8A:2049
+      FromPort: 2049
+      GroupId:
+        'Fn::GetAtt':
+          - RestateRestateSecurityGroup73273B13
+          - GroupId
+      IpProtocol: tcp
+      SourceSecurityGroupId:
+        'Fn::GetAtt':
+          - RestateRestateDataStoreEfsSecurityGroupF2C75FD3
+          - GroupId
+      ToPort: 2049
+  RestateRestateSecurityGroupfromRestateOnFargateStackRestateAlbSecurityGroup0956EE29808058F0BF62:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    Properties:
+      Description: Load balancer to target
+      FromPort: 8080
+      GroupId:
+        'Fn::GetAtt':
+          - RestateRestateSecurityGroup73273B13
+          - GroupId
+      IpProtocol: tcp
+      SourceSecurityGroupId:
+        'Fn::GetAtt':
+          - RestateAlbSecurityGroupFAAA5CAC
+          - GroupId
+      ToPort: 8080
+  RestateRestateSecurityGroupfromRestateOnFargateStackRestateAlbSecurityGroup0956EE299070AE51E8E6:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    Properties:
+      Description: Load balancer to target
+      FromPort: 9070
+      GroupId:
+        'Fn::GetAtt':
+          - RestateRestateSecurityGroup73273B13
+          - GroupId
+      IpProtocol: tcp
+      SourceSecurityGroupId:
+        'Fn::GetAtt':
+          - RestateAlbSecurityGroupFAAA5CAC
+          - GroupId
+      ToPort: 9070
+  RestateRestateServiceED254489:
+    Type: 'AWS::ECS::Service'
+    Properties:
+      Cluster:
+        Ref: RestateRestateClusterDED250CD
+      DeploymentConfiguration:
+        Alarms:
+          AlarmNames: []
+          Enable: false
+          Rollback: false
+        DeploymentCircuitBreaker:
+          Enable: true
+          Rollback: true
+        MaximumPercent: 100
+        MinimumHealthyPercent: 0
+      DeploymentController:
+        Type: ECS
+      EnableECSManagedTags: false
+      HealthCheckGracePeriodSeconds: 60
+      LaunchType: FARGATE
+      LoadBalancers:
+        - ContainerName: restate-runtime
+          ContainerPort: 8080
+          TargetGroupArn:
+            Ref: RestateAlbServiceListenerFargateServiceTargetGroup5051F748
+        - ContainerName: restate-runtime
+          ContainerPort: 9070
+          TargetGroupArn:
+            Ref: RestateAlbAdminListenerFargateAdminTargetGroupB830BB5A
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: ENABLED
+          SecurityGroups:
+            - 'Fn::GetAtt':
+                - RestateRestateSecurityGroup73273B13
+                - GroupId
+          Subnets:
+            - s-12345
+            - s-67890
+      TaskDefinition:
+        Ref: RestateRestateTask73B141AE
+    DependsOn:
+      - RestateAlbAdminListenerFargateAdminTargetGroupB830BB5A
+      - RestateAlbAdminListenerDEA13626
+      - RestateAlbServiceListenerFargateServiceTargetGroup5051F748
+      - RestateAlbServiceListenerF596018C
+      - RestateRestateTaskTaskRoleDefaultPolicyD6897EE5
+      - RestateRestateTaskTaskRole3425804E
+  RestateAlbDE422F47:
+    Type: 'AWS::ElasticLoadBalancingV2::LoadBalancer'
+    Properties:
+      LoadBalancerAttributes:
+        - Key: deletion_protection.enabled
+          Value: 'false'
+      Scheme: internet-facing
+      SecurityGroups:
+        - 'Fn::GetAtt':
+            - RestateAlbSecurityGroupFAAA5CAC
+            - GroupId
+      Subnets:
+        - s-12345
+        - s-67890
+      Type: application
+  RestateAlbSecurityGroupFAAA5CAC:
+    Type: 'AWS::EC2::SecurityGroup'
+    Properties:
+      GroupDescription: >-
+        Automatically created Security Group for ELB
+        RestateOnFargateStackRestateAlb82A45EC3
+      SecurityGroupIngress:
+        - CidrIp: 0.0.0.0/0
+          Description: Allow from anyone on port 443
+          FromPort: 443
+          IpProtocol: tcp
+          ToPort: 443
+        - CidrIp: 0.0.0.0/0
+          Description: Allow from anyone on port 9073
+          FromPort: 9073
+          IpProtocol: tcp
+          ToPort: 9073
+      VpcId: vpc-12345
+  RestateAlbSecurityGrouptoRestateOnFargateStackRestateRestateSecurityGroup7775CAEF80807AF04D73:
+    Type: 'AWS::EC2::SecurityGroupEgress'
+    Properties:
+      Description: Load balancer to target
+      DestinationSecurityGroupId:
+        'Fn::GetAtt':
+          - RestateRestateSecurityGroup73273B13
+          - GroupId
+      FromPort: 8080
+      GroupId:
+        'Fn::GetAtt':
+          - RestateAlbSecurityGroupFAAA5CAC
+          - GroupId
+      IpProtocol: tcp
+      ToPort: 8080
+  RestateAlbSecurityGrouptoRestateOnFargateStackRestateRestateSecurityGroup7775CAEF90704DBC4BF3:
+    Type: 'AWS::EC2::SecurityGroupEgress'
+    Properties:
+      Description: Load balancer to target
+      DestinationSecurityGroupId:
+        'Fn::GetAtt':
+          - RestateRestateSecurityGroup73273B13
+          - GroupId
+      FromPort: 9070
+      GroupId:
+        'Fn::GetAtt':
+          - RestateAlbSecurityGroupFAAA5CAC
+          - GroupId
+      IpProtocol: tcp
+      ToPort: 9070
+  RestateAlbServiceListenerF596018C:
+    Type: 'AWS::ElasticLoadBalancingV2::Listener'
+    Properties:
+      Certificates:
+        - CertificateArn:
+            Ref: RestateCertificateD6532EB8
+      DefaultActions:
+        - TargetGroupArn:
+            Ref: RestateAlbServiceListenerFargateServiceTargetGroup5051F748
+          Type: forward
+      LoadBalancerArn:
+        Ref: RestateAlbDE422F47
+      Port: 443
+      Protocol: HTTP
+  RestateAlbServiceListenerFargateServiceTargetGroup5051F748:
+    Type: 'AWS::ElasticLoadBalancingV2::TargetGroup'
+    Properties:
+      HealthCheckIntervalSeconds: 5
+      HealthCheckPath: /grpc.health.v1.Health/Check
+      HealthCheckTimeoutSeconds: 2
+      HealthyThresholdCount: 3
+      Port: 80
+      Protocol: HTTP
+      TargetGroupAttributes:
+        - Key: deregistration_delay.timeout_seconds
+          Value: '5'
+        - Key: stickiness.enabled
+          Value: 'false'
+      TargetType: ip
+      UnhealthyThresholdCount: 3
+      VpcId: vpc-12345
+  RestateAlbAdminListenerDEA13626:
+    Type: 'AWS::ElasticLoadBalancingV2::Listener'
+    Properties:
+      Certificates:
+        - CertificateArn:
+            Ref: RestateCertificateD6532EB8
+      DefaultActions:
+        - TargetGroupArn:
+            Ref: RestateAlbAdminListenerFargateAdminTargetGroupB830BB5A
+          Type: forward
+      LoadBalancerArn:
+        Ref: RestateAlbDE422F47
+      Port: 9073
+      Protocol: HTTPS
+  RestateAlbAdminListenerFargateAdminTargetGroupB830BB5A:
+    Type: 'AWS::ElasticLoadBalancingV2::TargetGroup'
+    Properties:
+      HealthCheckIntervalSeconds: 5
+      HealthCheckPath: /health
+      HealthCheckTimeoutSeconds: 2
+      HealthyThresholdCount: 3
+      Port: 80
+      Protocol: HTTP
+      TargetGroupAttributes:
+        - Key: deregistration_delay.timeout_seconds
+          Value: '5'
+        - Key: stickiness.enabled
+          Value: 'false'
+      TargetType: ip
+      UnhealthyThresholdCount: 3
+      VpcId: vpc-12345
+  RestateCertificateD6532EB8:
+    Type: 'AWS::CertificateManager::Certificate'
+    Properties:
+      DomainName: restate.example.com
+      DomainValidationOptions:
+        - DomainName: restate.example.com
+          HostedZoneId:
+            Ref: ZoneA5DE4B68
+      Tags:
+        - Key: Name
+          Value: RestateOnFargateStack/Restate/Certificate
+      ValidationMethod: DNS
+  RestateAlbAliasA12130FD:
+    Type: 'AWS::Route53::RecordSet'
+    Properties:
+      AliasTarget:
+        DNSName:
+          'Fn::Join':
+            - ''
+            - - dualstack.
+              - 'Fn::GetAtt':
+                  - RestateAlbDE422F47
+                  - DNSName
+        HostedZoneId:
+          'Fn::GetAtt':
+            - RestateAlbDE422F47
+            - CanonicalHostedZoneID
+      HostedZoneId:
+        Ref: ZoneA5DE4B68
+      Name: restate.example.com.
+      Type: A
+"
+`;
+
 exports[`Restate constructs Deploy a Lambda service handler to a remote Restate environment 1`] = `
 "Resources:
   InvokerRole4DB2757E:

--- a/test/e2e/fargate.e2e.ts
+++ b/test/e2e/fargate.e2e.ts
@@ -1,0 +1,22 @@
+import "source-map-support/register";
+import * as cdk from "aws-cdk-lib";
+import * as r53 from "aws-cdk-lib/aws-route53";
+import { FargateRestateDeployment } from "../../lib/restate-constructs";
+
+const app = new cdk.App();
+const stack = new cdk.Stack(app, "e2e-RestateOnFargate", {
+  env: { account: app.node.getContext("account"), region: app.node.getContext("region") },
+});
+
+const hostedZone = r53.HostedZone.fromLookup(stack, "HostedZone", {
+  domainName: app.node.getContext("domainName"),
+});
+
+const restate = new FargateRestateDeployment(stack, "Restate", {
+  dnsName: `${app.node.getContext("name")}.${hostedZone.zoneName}`,
+  hostedZone: hostedZone,
+});
+
+new cdk.CfnOutput(stack, "RestateIngressUrl", { value: restate.ingressUrl });
+
+app.synth();

--- a/test/restate-constructs.test.ts
+++ b/test/restate-constructs.test.ts
@@ -1,15 +1,52 @@
 import * as cdk from "aws-cdk-lib";
-import { RestateEnvironment, ServiceDeployer } from "../lib/restate-constructs";
+import {
+  FargateRestateDeployment,
+  RestateEnvironment,
+  ServiceDeployer,
+  SingleNodeRestateDeployment,
+} from "../lib/restate-constructs";
 import { Construct } from "constructs";
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import * as secretsmanager from "aws-cdk-lib/aws-secretsmanager";
 import * as iam from "aws-cdk-lib/aws-iam";
+import * as route53 from "aws-cdk-lib/aws-route53";
 import "jest-cdk-snapshot";
 
 describe("Restate constructs", () => {
   test("Deploy a Lambda service handler to a remote Restate environment", () => {
     const app = new cdk.App();
     const stack = new LambdaServiceDeployment(app, "LambdaServiceDeployment", {});
+
+    expect(stack).toMatchCdkSnapshot({
+      ignoreAssets: true,
+      yaml: true,
+    });
+  });
+
+  test("Create a self-hosted Restate environment deployed on ECS Fargate", () => {
+    const app = new cdk.App();
+    const stack = new cdk.Stack(app, "RestateOnFargateStack", {
+      env: { account: "account-id", region: "region" },
+    });
+
+    new FargateRestateDeployment(stack, "Restate", {
+      hostedZone: new route53.HostedZone(stack, "Zone", { zoneName: "example.com" }),
+      dnsName: "restate.example.com",
+    });
+
+    expect(stack).toMatchCdkSnapshot({
+      ignoreAssets: true,
+      yaml: true,
+    });
+  });
+
+  test("Create a self-hosted Restate environment deployed on EC2", () => {
+    const app = new cdk.App();
+    const stack = new cdk.Stack(app, "RestateOnFargateStack", {
+      env: { account: "account-id", region: "region" },
+    });
+
+    new SingleNodeRestateDeployment(stack, "Restate", {});
 
     expect(stack).toMatchCdkSnapshot({
       ignoreAssets: true,


### PR DESCRIPTION
Add a Fargate deployment target as an alternative to bare EC2 instance. This requires the use of EFS due to the insufficient ECS integration with long-lived EBS volumes.