### PR TITLE
Multiple Service Deployer enhancements

### DIFF
--- a/test/__snapshots__/restate-constructs.test.ts.snap
+++ b/test/__snapshots__/restate-constructs.test.ts.snap
@@ -1250,7 +1250,6 @@ exports[`Restate constructs Deploy a Lambda service handler to Restate Cloud env
         'Fn::GetAtt':
           - ServiceDeployerCustomResourceProviderframeworkonEvent528FE6C2
           - Arn
-      servicePath: Service
       adminUrl: 'https://test.env.us.restate.cloud:9070'
       authTokenSecretArn:
         'Fn::Join':
@@ -1513,7 +1512,6 @@ exports[`Restate constructs Deploy a Lambda service handler to existing Restate 
         'Fn::GetAtt':
           - ServiceDeployerCustomResourceProviderframeworkonEvent528FE6C2
           - Arn
-      servicePath: Service
       adminUrl: 'https://restate.example.com:9070'
       authTokenSecretArn:
         Ref: RestateApiKey6463672F

--- a/test/restate-constructs.test.ts
+++ b/test/restate-constructs.test.ts
@@ -36,7 +36,7 @@ describe("Restate constructs", () => {
       // only needed in testing, where the relative path of the registration function is different from how customers would use it
       entry: "dist/register-service-handler/index.js",
     });
-    serviceDeployer.deployService("Service", handler.currentVersion, cloudEnvironment);
+    serviceDeployer.register(handler.currentVersion, cloudEnvironment);
 
     expect(stack).toMatchCdkSnapshot({
       ignoreAssets: true,
@@ -71,7 +71,7 @@ describe("Restate constructs", () => {
       // only needed in testing, where the relative path of the registration function is different from how customers would use it
       entry: "dist/register-service-handler/index.js",
     });
-    serviceDeployer.deployService("Service", handler.currentVersion, restateEnvironment);
+    serviceDeployer.register(handler.currentVersion, restateEnvironment);
 
     expect(stack).toMatchCdkSnapshot({
       ignoreAssets: true,


### PR DESCRIPTION
The Service Deployer construct now exposes a new method to deploy handlers without explicitly naming the service being deployed.

The custom resource hook now sets visibility for all services housed in the same handler, not just the named service.

Ergonomic enhancement: when deploying the `$LATEST` alias, the deployer will automatically add a variable config property to trigger discovery on every deployment.

Finally, we drop compatibility with old Restate server versions lower than 0.7.