### PR TITLE
Fix ServiceDeployer bundling properties propagation

### DIFF
--- a/lib/restate-constructs/service-deployer.ts
+++ b/lib/restate-constructs/service-deployer.ts
@@ -122,7 +122,7 @@ export class ServiceDeployer extends Construct {
       environment: {
         NODE_OPTIONS: "--enable-source-maps",
       },
-      bundling: {
+      bundling: props?.bundling ?? {
         minify: false,
         sourceMap: true,
       },

--- a/test/__snapshots__/restate-constructs.test.ts.snap
+++ b/test/__snapshots__/restate-constructs.test.ts.snap
@@ -1765,3 +1765,123 @@ Mappings:
       value: nodejs20.x
 "
 `;
+
+exports[`Restate constructs Service Deployer overrides 1`] = `
+"Resources:
+  ServiceDeployerEventHandlerServiceRoleF133584F:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: 'sts:AssumeRole'
+            Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+        Version: '2012-10-17'
+      ManagedPolicyArns:
+        - 'Fn::Join':
+            - ''
+            - - 'arn:'
+              - Ref: 'AWS::Partition'
+              - ':iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
+  ServiceDeployerEventHandler89EAD25F:
+    Type: 'AWS::Lambda::Function'
+    Properties:
+      Architectures:
+        - arm64
+      Code:
+        S3Bucket: cdk-hnb659fds-assets-account-id-region
+        S3Key: 306482e190035b7e874091243db3832ecc2693d3f1989445f3b7f5ffff2957fe.zip
+      Description: Restate custom registration handler
+      Environment:
+        Variables:
+          NODE_OPTIONS: '--enable-source-maps'
+      Handler: index.handler
+      MemorySize: 128
+      Role:
+        'Fn::GetAtt':
+          - ServiceDeployerEventHandlerServiceRoleF133584F
+          - Arn
+      Runtime: nodejs18.x
+      Timeout: 180
+    DependsOn:
+      - ServiceDeployerEventHandlerServiceRoleF133584F
+  ServiceDeployerDeploymentLogs5B8BE5D2:
+    Type: 'AWS::Logs::LogGroup'
+    Properties:
+      LogGroupName:
+        'Fn::Join':
+          - ''
+          - - /aws/lambda/
+            - Ref: ServiceDeployerEventHandler89EAD25F
+      RetentionInDays: 30
+    UpdateReplacePolicy: Retain
+    DeletionPolicy: RetainExceptOnCreate
+  ServiceDeployerCustomResourceProviderframeworkonEventServiceRole865AFB0C:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: 'sts:AssumeRole'
+            Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+        Version: '2012-10-17'
+      ManagedPolicyArns:
+        - 'Fn::Join':
+            - ''
+            - - 'arn:'
+              - Ref: 'AWS::Partition'
+              - ':iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
+  ServiceDeployerCustomResourceProviderframeworkonEventServiceRoleDefaultPolicy740A65C9:
+    Type: 'AWS::IAM::Policy'
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action: 'lambda:InvokeFunction'
+            Effect: Allow
+            Resource:
+              - 'Fn::GetAtt':
+                  - ServiceDeployerEventHandler89EAD25F
+                  - Arn
+              - 'Fn::Join':
+                  - ''
+                  - - 'Fn::GetAtt':
+                        - ServiceDeployerEventHandler89EAD25F
+                        - Arn
+                    - ':*'
+        Version: '2012-10-17'
+      PolicyName: >-
+        ServiceDeployerCustomResourceProviderframeworkonEventServiceRoleDefaultPolicy740A65C9
+      Roles:
+        - Ref: >-
+            ServiceDeployerCustomResourceProviderframeworkonEventServiceRole865AFB0C
+  ServiceDeployerCustomResourceProviderframeworkonEvent528FE6C2:
+    Type: 'AWS::Lambda::Function'
+    Properties:
+      Code:
+        S3Bucket: cdk-hnb659fds-assets-account-id-region
+        S3Key: 4dc48ffba382f93077a1e6824599bbd4ceb6f91eb3d9442eca3b85bdb1a20b1e.zip
+      Description: >-
+        AWS CDK resource provider framework - onEvent
+        (RestateCloudStack/ServiceDeployer/CustomResourceProvider)
+      Environment:
+        Variables:
+          USER_ON_EVENT_FUNCTION_ARN:
+            'Fn::GetAtt':
+              - ServiceDeployerEventHandler89EAD25F
+              - Arn
+      Handler: framework.onEvent
+      Role:
+        'Fn::GetAtt':
+          - >-
+            ServiceDeployerCustomResourceProviderframeworkonEventServiceRole865AFB0C
+          - Arn
+      Runtime: nodejs18.x
+      Timeout: 900
+    DependsOn:
+      - >-
+        ServiceDeployerCustomResourceProviderframeworkonEventServiceRoleDefaultPolicy740A65C9
+      - ServiceDeployerCustomResourceProviderframeworkonEventServiceRole865AFB0C
+"
+`;

--- a/test/e2e/deploy-ec2-alb.sh
+++ b/test/e2e/deploy-ec2-alb.sh
@@ -1,0 +1,12 @@
+set -euf -o pipefail
+
+# need to run in dev so it can access the dev.restate.cloud hosted zone
+npx cdk --app 'npx tsx single-node-ec2-alb.e2e.ts' \
+    --profile restate-cloud-dev-admin \
+    deploy \
+    --output cdk.ec2-alb.out \
+    --context vpc_id=vpc-058ff0dc027b2df5a \
+    --context domainName=dev.restate.cloud \
+    --context hostname=single-node-ec2 #\
+#    --require-approval never \
+#    --no-rollback

--- a/test/e2e/deploy-ec2-direct.sh
+++ b/test/e2e/deploy-ec2-direct.sh
@@ -1,0 +1,8 @@
+set -euf -o pipefail
+
+npx cdk --app 'npx tsx single-node-ec2.e2e.ts' \
+    --profile restate-eng \
+    deploy \
+    --require-approval never
+#    --no-rollback
+#    --context vpc_id=vpc-0d2e373fed47934f3 \ # VPC in mgmt account 663487780041 with egress gw

--- a/test/e2e/deploy-restate-cloud-lambda.e2e.sh
+++ b/test/e2e/deploy-restate-cloud-lambda.e2e.sh
@@ -1,0 +1,11 @@
+set -euf -o pipefail
+
+export AWS_PROFILE=restate-eng RESTATE_ENV_ID=env_201j8ncr31esdhxzkk8jzkkgffw RESTATE_API_KEY=key_10urPk2V8gxnLKo84E7RYum.EfiNa3UiVoXKXmRbGBTPhifFv6uMeRch68rKotZRLwLM
+export RESTATE_ENV_URL=https://$(echo $RESTATE_ENV_ID | cut -f2 -d_).env.us.restate.cloud/Greeter/greet
+
+npx cdk --app 'npx tsx restate-cloud.e2e.ts' synth
+npx cdk --app 'npx tsx restate-cloud.e2e.ts' deploy --require-approval never --no-rollback
+
+curl $RESTATE_ENV_URL -H "Authorization: Bearer $RESTATE_API_KEY" --json '"e2e-test"'
+
+npx cdk --app 'npx tsx restate-cloud.e2e.ts' destroy --force

--- a/test/e2e/destroy-ec2-alb.sh
+++ b/test/e2e/destroy-ec2-alb.sh
@@ -1,0 +1,11 @@
+set -euf -o pipefail
+
+# need to run in dev so it can access the dev.restate.cloud hosted zone
+npx cdk --app 'npx tsx single-node-ec2-alb.e2e.ts' \
+    --profile restate-cloud-dev-admin \
+    destroy \
+    --output cdk.ec2-alb.out \
+    --context vpc_id=vpc-058ff0dc027b2df5a \
+    --context domainName=dev.restate.cloud \
+    --context hostname=single-node-ec2 \
+    --force

--- a/test/restate-constructs.test.ts
+++ b/test/restate-constructs.test.ts
@@ -44,6 +44,27 @@ describe("Restate constructs", () => {
     });
   });
 
+  test("Service Deployer overrides", () => {
+    const app = new cdk.App();
+    const stack = new cdk.Stack(app, "RestateCloudStack", {
+      env: { account: "account-id", region: "region" },
+    });
+    const serviceDeployer = new ServiceDeployer(stack, "ServiceDeployer", {
+      // only needed in testing, where the relative path of the registration function is different from how customers would use it
+      entry: "dist/register-service-handler/index.js",
+      bundling: {
+        minify: true,
+        sourceMap: false,
+        target: "node20",
+      }
+    });
+
+    expect(stack).toMatchCdkSnapshot({
+      ignoreAssets: false,
+      yaml: true,
+    });
+  });
+
   test("Deploy a Lambda service handler to existing Restate environment", () => {
     const app = new cdk.App();
     const stack = new cdk.Stack(app, "LambdaServiceDeployment", {});

--- a/test/restate-constructs.test.ts
+++ b/test/restate-constructs.test.ts
@@ -56,7 +56,7 @@ describe("Restate constructs", () => {
         minify: true,
         sourceMap: false,
         target: "node20",
-      }
+      },
     });
 
     expect(stack).toMatchCdkSnapshot({


### PR DESCRIPTION
PR #47 introduced a new `bundling` property but did not properly wire it up to the underlying construct. This change takes care of that.