### PR TITLE
Make RestateCloudEnvironments read-only properties public

### DIFF
--- a/lib/restate-constructs/restate-cloud-environment.ts
+++ b/lib/restate-constructs/restate-cloud-environment.ts
@@ -30,7 +30,7 @@ export interface RestateCloudEnvironmentProps {
   readonly apiKey: secrets.ISecret;
 
   /**
-   * Region of the environment. Defaults to "us".
+   * Region of the environment. Defaults to `us`. Valid values: [`us`, `eu`].
    */
   readonly region?: RestateCloudRegion;
 }
@@ -40,11 +40,12 @@ export interface RestateCloudEnvironmentProps {
  * [Restate Cloud](https://cloud.restate.dev/) hosted service.
  */
 export class RestateCloudEnvironment extends Construct implements IRestateEnvironment {
-  readonly adminUrl: string;
-  readonly ingressUrl: string;
-  readonly authToken: secrets.ISecret;
-  readonly invokerRole: iam.IRole;
-  readonly region: RestateCloudRegion;
+  public readonly environmentId: EnvironmentId;
+  public readonly adminUrl: string;
+  public readonly ingressUrl: string;
+  public readonly authToken: secrets.ISecret;
+  public readonly invokerRole: iam.IRole;
+  public readonly region: RestateCloudRegion;
 
   /**
    * Constructs a Restate Cloud environment reference along with invoker. Note that this construct is only a pointer to
@@ -60,6 +61,7 @@ export class RestateCloudEnvironment extends Construct implements IRestateEnviro
    */
   constructor(scope: Construct, id: string, props: RestateCloudEnvironmentProps) {
     super(scope, id);
+    this.environmentId = props.environmentId;
     this.region = props.region ?? RESTATE_CLOUD_REGION_US;
     this.invokerRole = this.createInvokerRole(this, props);
     this.authToken = props.apiKey;
@@ -102,7 +104,7 @@ function ingressEndpoint(region: RestateCloudRegion, environmentId: EnvironmentI
 }
 
 export type EnvironmentId = `env_${string}`;
-type RestateCloudRegion = "us" | "eu";
+export type RestateCloudRegion = "us" | "eu";
 
 interface RegionConfig {
   accountId: string;

--- a/lib/restate-constructs/restate-cloud-environment.ts
+++ b/lib/restate-constructs/restate-cloud-environment.ts
@@ -74,7 +74,7 @@ export class RestateCloudEnvironment extends Construct implements IRestateEnviro
    * not attempt to create an invoker role, but still returns an Environment object which can be used to deploy
    * services.
    *
-   * @param props environment properties - only `environmentId` and `authToken` are required
+   * @param props environment properties - only `environmentId` and `apiKey` are required
    */
   static fromAttributes(props: {
     environmentId: EnvironmentId;

--- a/lib/restate-constructs/restate-cloud-environment.ts
+++ b/lib/restate-constructs/restate-cloud-environment.ts
@@ -40,12 +40,12 @@ export interface RestateCloudEnvironmentProps {
  * [Restate Cloud](https://cloud.restate.dev/) hosted service.
  */
 export class RestateCloudEnvironment extends Construct implements IRestateEnvironment {
-  public readonly environmentId: EnvironmentId;
-  public readonly adminUrl: string;
-  public readonly ingressUrl: string;
-  public readonly authToken: secrets.ISecret;
-  public readonly invokerRole: iam.IRole;
-  public readonly region: RestateCloudRegion;
+  readonly environmentId: EnvironmentId;
+  readonly adminUrl: string;
+  readonly ingressUrl: string;
+  readonly authToken: secrets.ISecret;
+  readonly invokerRole: iam.IRole;
+  readonly region: RestateCloudRegion;
 
   /**
    * Constructs a Restate Cloud environment reference along with invoker. Note that this construct is only a pointer to
@@ -67,6 +67,28 @@ export class RestateCloudEnvironment extends Construct implements IRestateEnviro
     this.authToken = props.apiKey;
     this.adminUrl = adminEndpoint(this.region, props.environmentId);
     this.ingressUrl = ingressEndpoint(this.region, props.environmentId);
+  }
+
+  /**
+   * Creates a reference to an existing Restate Cloud environment. Unlike instantiating the construct, this variant does
+   * not attempt to create an invoker role, but still returns an Environment object which can be used to deploy
+   * services.
+   *
+   * @param props environment properties - only `environmentId` and `authToken` are required
+   */
+  static fromAttributes(props: {
+    environmentId: EnvironmentId;
+    apiKey: secrets.ISecret;
+    invokerRole: iam.IRole;
+    region?: RestateCloudRegion;
+    adminUrl?: string;
+  }) {
+    const region = props?.region ?? RESTATE_CLOUD_REGION_US;
+    return RestateEnvironment.fromAttributes({
+      invokerRole: props?.invokerRole,
+      adminUrl: props?.adminUrl ?? adminEndpoint(region, props.environmentId),
+      authToken: props?.apiKey,
+    });
   }
 
   /**

--- a/lib/restate-constructs/restate-cloud-environment.ts
+++ b/lib/restate-constructs/restate-cloud-environment.ts
@@ -50,8 +50,8 @@ export class RestateCloudEnvironment extends Construct implements IRestateEnviro
   /**
    * Constructs a Restate Cloud environment reference along with invoker. Note that this construct is only a pointer to
    * an existing Restate Cloud environment and does not create it. However, it does create an invoker role that is used
-   * invoking Lambda service handlers. If you would prefer to directly manage the invoker role permissions, you can
-   * override the {@link createInvokerRole} method or construct one yourself and define the environment properties with
+   * invoking Lambda service handlers. If you prefer to directly manage the invoker role permissions, you can override
+   * the {@link createInvokerRole} method or construct one yourself and define the environment properties with
    * {@link RestateEnvironment.fromAttributes} directly.
    *
    * @param scope parent construct

--- a/lib/restate-constructs/restate-environment.ts
+++ b/lib/restate-constructs/restate-environment.ts
@@ -48,7 +48,6 @@ export class RestateEnvironment implements IRestateEnvironment {
   readonly adminUrl: string;
   readonly authToken?: secrets.ISecret;
   readonly invokerRole?: iam.IRole;
-  readonly serviceDeployer: ServiceDeployer;
 
   private constructor(props: IRestateEnvironment) {
     this.adminUrl = props.adminUrl;

--- a/lib/restate-constructs/restate-environment.ts
+++ b/lib/restate-constructs/restate-environment.ts
@@ -12,7 +12,6 @@
 import * as iam from "aws-cdk-lib/aws-iam";
 import * as secrets from "aws-cdk-lib/aws-secretsmanager";
 import { FunctionOptions } from "aws-cdk-lib/aws-lambda";
-import { ServiceDeployer } from "./service-deployer";
 import { SingleNodeRestateDeployment } from "./single-node-restate-deployment";
 import { RestateCloudEnvironment } from "./restate-cloud-environment";
 

--- a/test/__snapshots__/restate-constructs.test.ts.snap
+++ b/test/__snapshots__/restate-constructs.test.ts.snap
@@ -1768,6 +1768,282 @@ Mappings:
 "
 `;
 
+exports[`Restate constructs Reference an existing Cloud Environment 1`] = `
+"Resources:
+  RestateServiceHandlerServiceRole07B26D05:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: 'sts:AssumeRole'
+            Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+        Version: '2012-10-17'
+      ManagedPolicyArns:
+        - 'Fn::Join':
+            - ''
+            - - 'arn:'
+              - Ref: 'AWS::Partition'
+              - ':iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
+  RestateServiceHandler71409CD7:
+    Type: 'AWS::Lambda::Function'
+    Properties:
+      Code: Any<Object>
+      Handler: index.handler
+      Role:
+        'Fn::GetAtt':
+          - RestateServiceHandlerServiceRole07B26D05
+          - Arn
+      Runtime: nodejs18.x
+    DependsOn:
+      - RestateServiceHandlerServiceRole07B26D05
+  RestateServiceHandlerCurrentVersion40030E671fc2ba09c2d7b4ea8c6a3f8fee895a65:
+    Type: 'AWS::Lambda::Version'
+    Properties:
+      FunctionName:
+        Ref: RestateServiceHandler71409CD7
+  RestateServiceHandlerCurrentVersionRestateDeploymentE8F102EB:
+    Type: 'Custom::RestateServiceDeployment'
+    Properties:
+      ServiceToken:
+        'Fn::GetAtt':
+          - ServiceDeployerCustomResourceProviderframeworkonEvent528FE6C2
+          - Arn
+      adminUrl: 'https://e1.env.eu.restate.cloud:9070'
+      authTokenSecretArn:
+        'Fn::Join':
+          - ''
+          - - 'arn:'
+            - Ref: 'AWS::Partition'
+            - ':secretsmanager:region:account-id:secret:secret_name'
+      serviceLambdaArn:
+        Ref: >-
+          RestateServiceHandlerCurrentVersion40030E671fc2ba09c2d7b4ea8c6a3f8fee895a65
+      invokeRoleArn: 'arn:aws:iam::654654156625:role/Invoker'
+      removalPolicy: retain
+      private: 'false'
+      insecure: 'false'
+    DependsOn:
+      - ServiceDeployerInvocationPolicyD09B639D
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Delete
+  ServiceDeployerEventHandlerServiceRoleF133584F:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: 'sts:AssumeRole'
+            Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+        Version: '2012-10-17'
+      ManagedPolicyArns:
+        - 'Fn::Join':
+            - ''
+            - - 'arn:'
+              - Ref: 'AWS::Partition'
+              - ':iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
+  ServiceDeployerEventHandlerServiceRoleDefaultPolicyFE2DC3C9:
+    Type: 'AWS::IAM::Policy'
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action:
+              - 'secretsmanager:GetSecretValue'
+              - 'secretsmanager:DescribeSecret'
+            Effect: Allow
+            Resource:
+              'Fn::Join':
+                - ''
+                - - 'arn:'
+                  - Ref: 'AWS::Partition'
+                  - ':secretsmanager:region:account-id:secret:secret_name-??????'
+        Version: '2012-10-17'
+      PolicyName: ServiceDeployerEventHandlerServiceRoleDefaultPolicyFE2DC3C9
+      Roles:
+        - Ref: ServiceDeployerEventHandlerServiceRoleF133584F
+  ServiceDeployerEventHandler89EAD25F:
+    Type: 'AWS::Lambda::Function'
+    Properties:
+      Architectures:
+        - arm64
+      Code: Any<Object>
+      Description: Restate custom registration handler
+      Environment:
+        Variables:
+          NODE_OPTIONS: '--enable-source-maps'
+      Handler: index.handler
+      MemorySize: 128
+      Role:
+        'Fn::GetAtt':
+          - ServiceDeployerEventHandlerServiceRoleF133584F
+          - Arn
+      Runtime: nodejs18.x
+      Timeout: 180
+    DependsOn:
+      - ServiceDeployerEventHandlerServiceRoleDefaultPolicyFE2DC3C9
+      - ServiceDeployerEventHandlerServiceRoleF133584F
+  ServiceDeployerDeploymentLogs5B8BE5D2:
+    Type: 'AWS::Logs::LogGroup'
+    Properties:
+      LogGroupName:
+        'Fn::Join':
+          - ''
+          - - /aws/lambda/
+            - Ref: ServiceDeployerEventHandler89EAD25F
+      RetentionInDays: 30
+    UpdateReplacePolicy: Retain
+    DeletionPolicy: RetainExceptOnCreate
+  ServiceDeployerCustomResourceProviderframeworkonEventServiceRole865AFB0C:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: 'sts:AssumeRole'
+            Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+        Version: '2012-10-17'
+      ManagedPolicyArns:
+        - 'Fn::Join':
+            - ''
+            - - 'arn:'
+              - Ref: 'AWS::Partition'
+              - ':iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
+  ServiceDeployerCustomResourceProviderframeworkonEventServiceRoleDefaultPolicy740A65C9:
+    Type: 'AWS::IAM::Policy'
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action: 'lambda:InvokeFunction'
+            Effect: Allow
+            Resource:
+              - 'Fn::GetAtt':
+                  - ServiceDeployerEventHandler89EAD25F
+                  - Arn
+              - 'Fn::Join':
+                  - ''
+                  - - 'Fn::GetAtt':
+                        - ServiceDeployerEventHandler89EAD25F
+                        - Arn
+                    - ':*'
+        Version: '2012-10-17'
+      PolicyName: >-
+        ServiceDeployerCustomResourceProviderframeworkonEventServiceRoleDefaultPolicy740A65C9
+      Roles:
+        - Ref: >-
+            ServiceDeployerCustomResourceProviderframeworkonEventServiceRole865AFB0C
+  ServiceDeployerCustomResourceProviderframeworkonEvent528FE6C2:
+    Type: 'AWS::Lambda::Function'
+    Properties:
+      Code: Any<Object>
+      Description: >-
+        AWS CDK resource provider framework - onEvent
+        (RestateCloudStack/ServiceDeployer/CustomResourceProvider)
+      Environment:
+        Variables:
+          USER_ON_EVENT_FUNCTION_ARN:
+            'Fn::GetAtt':
+              - ServiceDeployerEventHandler89EAD25F
+              - Arn
+      Handler: framework.onEvent
+      Role:
+        'Fn::GetAtt':
+          - >-
+            ServiceDeployerCustomResourceProviderframeworkonEventServiceRole865AFB0C
+          - Arn
+      Runtime: nodejs18.x
+      Timeout: 900
+    DependsOn:
+      - >-
+        ServiceDeployerCustomResourceProviderframeworkonEventServiceRoleDefaultPolicy740A65C9
+      - ServiceDeployerCustomResourceProviderframeworkonEventServiceRole865AFB0C
+  ServiceDeployerInvocationPolicyD09B639D:
+    Type: 'AWS::IAM::Policy'
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action: 'lambda:InvokeFunction'
+            Effect: Allow
+            Resource:
+              - 'Fn::GetAtt':
+                  - RestateServiceHandler71409CD7
+                  - Arn
+              - 'Fn::Join':
+                  - ''
+                  - - 'Fn::GetAtt':
+                        - RestateServiceHandler71409CD7
+                        - Arn
+                    - ':*'
+        Version: '2012-10-17'
+      PolicyName: ServiceDeployerInvocationPolicyD09B639D
+      Roles:
+        - Invoker
+"
+`;
+
+exports[`Restate constructs Restate Cloud Environment construct 1`] = `
+"Resources:
+  e1InvokerRoleEEC53B29:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: 'sts:AssumeRole'
+            Condition:
+              StringEquals:
+                'sts:ExternalId': env_e1
+                'aws:PrincipalArn': 'arn:aws:iam::654654156625:role/RestateCloud'
+            Effect: Allow
+            Principal:
+              AWS:
+                'Fn::Join':
+                  - ''
+                  - - 'arn:'
+                    - Ref: 'AWS::Partition'
+                    - ':iam::654654156625:root'
+          - Action: 'sts:TagSession'
+            Effect: Allow
+            Principal:
+              AWS:
+                'Fn::Join':
+                  - ''
+                  - - 'arn:'
+                    - Ref: 'AWS::Partition'
+                    - ':iam::654654156625:root'
+        Version: '2012-10-17'
+  e2InvokerRoleFFCF8E05:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: 'sts:AssumeRole'
+            Condition:
+              StringEquals:
+                'sts:ExternalId': env_e2
+                'aws:PrincipalArn': 'arn:aws:iam::654654156625:role/RestateCloud'
+            Effect: Allow
+            Principal:
+              AWS:
+                'Fn::Join':
+                  - ''
+                  - - 'arn:'
+                    - Ref: 'AWS::Partition'
+                    - ':iam::654654156625:root'
+          - Action: 'sts:TagSession'
+            Effect: Allow
+            Principal:
+              AWS:
+                'Fn::Join':
+                  - ''
+                  - - 'arn:'
+                    - Ref: 'AWS::Partition'
+                    - ':iam::654654156625:root'
+        Version: '2012-10-17'
+"
+`;
+
 exports[`Restate constructs Service Deployer overrides 1`] = `
 "Resources:
   ServiceDeployerEventHandlerServiceRoleF133584F:

--- a/test/__snapshots__/restate-constructs.test.ts.snap
+++ b/test/__snapshots__/restate-constructs.test.ts.snap
@@ -1768,7 +1768,68 @@ Mappings:
 "
 `;
 
-exports[`Restate constructs Reference an existing Cloud Environment 1`] = `
+exports[`Restate constructs Restate Cloud Environment construct 1`] = `
+"Resources:
+  e1InvokerRoleEEC53B29:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: 'sts:AssumeRole'
+            Condition:
+              StringEquals:
+                'sts:ExternalId': env_e1
+                'aws:PrincipalArn': 'arn:aws:iam::654654156625:role/RestateCloud'
+            Effect: Allow
+            Principal:
+              AWS:
+                'Fn::Join':
+                  - ''
+                  - - 'arn:'
+                    - Ref: 'AWS::Partition'
+                    - ':iam::654654156625:root'
+          - Action: 'sts:TagSession'
+            Effect: Allow
+            Principal:
+              AWS:
+                'Fn::Join':
+                  - ''
+                  - - 'arn:'
+                    - Ref: 'AWS::Partition'
+                    - ':iam::654654156625:root'
+        Version: '2012-10-17'
+  e2InvokerRoleFFCF8E05:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: 'sts:AssumeRole'
+            Condition:
+              StringEquals:
+                'sts:ExternalId': env_e2
+                'aws:PrincipalArn': 'arn:aws:iam::654654156625:role/RestateCloud'
+            Effect: Allow
+            Principal:
+              AWS:
+                'Fn::Join':
+                  - ''
+                  - - 'arn:'
+                    - Ref: 'AWS::Partition'
+                    - ':iam::654654156625:root'
+          - Action: 'sts:TagSession'
+            Effect: Allow
+            Principal:
+              AWS:
+                'Fn::Join':
+                  - ''
+                  - - 'arn:'
+                    - Ref: 'AWS::Partition'
+                    - ':iam::654654156625:root'
+        Version: '2012-10-17'
+"
+`;
+
+exports[`Restate constructs Restate Cloud Environment construct with role reference 1`] = `
 "Resources:
   RestateServiceHandlerServiceRole07B26D05:
     Type: 'AWS::IAM::Role'
@@ -1980,67 +2041,6 @@ exports[`Restate constructs Reference an existing Cloud Environment 1`] = `
       PolicyName: ServiceDeployerInvocationPolicyD09B639D
       Roles:
         - Invoker
-"
-`;
-
-exports[`Restate constructs Restate Cloud Environment construct 1`] = `
-"Resources:
-  e1InvokerRoleEEC53B29:
-    Type: 'AWS::IAM::Role'
-    Properties:
-      AssumeRolePolicyDocument:
-        Statement:
-          - Action: 'sts:AssumeRole'
-            Condition:
-              StringEquals:
-                'sts:ExternalId': env_e1
-                'aws:PrincipalArn': 'arn:aws:iam::654654156625:role/RestateCloud'
-            Effect: Allow
-            Principal:
-              AWS:
-                'Fn::Join':
-                  - ''
-                  - - 'arn:'
-                    - Ref: 'AWS::Partition'
-                    - ':iam::654654156625:root'
-          - Action: 'sts:TagSession'
-            Effect: Allow
-            Principal:
-              AWS:
-                'Fn::Join':
-                  - ''
-                  - - 'arn:'
-                    - Ref: 'AWS::Partition'
-                    - ':iam::654654156625:root'
-        Version: '2012-10-17'
-  e2InvokerRoleFFCF8E05:
-    Type: 'AWS::IAM::Role'
-    Properties:
-      AssumeRolePolicyDocument:
-        Statement:
-          - Action: 'sts:AssumeRole'
-            Condition:
-              StringEquals:
-                'sts:ExternalId': env_e2
-                'aws:PrincipalArn': 'arn:aws:iam::654654156625:role/RestateCloud'
-            Effect: Allow
-            Principal:
-              AWS:
-                'Fn::Join':
-                  - ''
-                  - - 'arn:'
-                    - Ref: 'AWS::Partition'
-                    - ':iam::654654156625:root'
-          - Action: 'sts:TagSession'
-            Effect: Allow
-            Principal:
-              AWS:
-                'Fn::Join':
-                  - ''
-                  - - 'arn:'
-                    - Ref: 'AWS::Partition'
-                    - ':iam::654654156625:root'
-        Version: '2012-10-17'
 "
 `;
 

--- a/test/restate-constructs.test.ts
+++ b/test/restate-constructs.test.ts
@@ -50,7 +50,7 @@ describe("Restate constructs", () => {
     });
   });
 
-  test("Reference an existing Cloud Environment", () => {
+  test("Restate Cloud Environment construct with role reference", () => {
     const app = new cdk.App();
     const stack = new cdk.Stack(app, "RestateCloudStack", {
       env: { account: "account-id", region: "region" },
@@ -59,8 +59,7 @@ describe("Restate constructs", () => {
 
     const invokerRole = iam.Role.fromRoleArn(stack, "InvokerRole", "arn:aws:iam::654654156625:role/Invoker");
 
-    // Construct a Cloud environment from a known attributes
-    const cloudEnvironment = RestateCloudEnvironment.fromAttributes({
+    const cloudEnvironment = new RestateCloudEnvironment(stack, "e1", {
       environmentId: "env_e1",
       apiKey,
       invokerRole,

--- a/test/restate-constructs.test.ts
+++ b/test/restate-constructs.test.ts
@@ -15,7 +15,7 @@ import {
 import { FargateRestateDeployment } from "../lib/restate-constructs";
 
 describe("Restate constructs", () => {
-  test("Cloud Environment API", () => {
+  test("Restate Cloud Environment construct", () => {
     const app = new cdk.App();
     const stack = new cdk.Stack(app, "RestateCloudStack", {
       env: { account: "account-id", region: "region" },
@@ -43,6 +43,44 @@ describe("Restate constructs", () => {
     expect(e2.ingressUrl).toBe("https://e2.env.eu.restate.cloud");
     expect(e2.adminUrl).toBe("https://e2.env.eu.restate.cloud:9070");
     expect(e2.authToken).toBe(apiKey);
+
+    expect(stack).toMatchCdkSnapshot({
+      ignoreAssets: true,
+      yaml: true,
+    });
+  });
+
+  test("Reference an existing Cloud Environment", () => {
+    const app = new cdk.App();
+    const stack = new cdk.Stack(app, "RestateCloudStack", {
+      env: { account: "account-id", region: "region" },
+    });
+    const apiKey = secrets.Secret.fromSecretNameV2(stack, "CloudApiKey", "secret_name");
+
+    const invokerRole = iam.Role.fromRoleArn(stack, "InvokerRole", "arn:aws:iam::654654156625:role/Invoker");
+
+    // Construct a Cloud environment from a known attributes
+    const cloudEnvironment = RestateCloudEnvironment.fromAttributes({
+      environmentId: "env_e1",
+      apiKey,
+      invokerRole,
+      region: "eu",
+    });
+
+    expect(cloudEnvironment.adminUrl).toBe("https://e1.env.eu.restate.cloud:9070");
+    expect(cloudEnvironment.authToken).toBe(apiKey);
+
+    const handler = mockHandler(stack);
+    const serviceDeployer = new ServiceDeployer(stack, "ServiceDeployer", {
+      // only needed in testing, where the relative path of the registration function is different from how customers would use it
+      entry: "dist/register-service-handler/index.js",
+    });
+    serviceDeployer.register(handler.currentVersion, cloudEnvironment);
+
+    expect(stack).toMatchCdkSnapshot({
+      ignoreAssets: true,
+      yaml: true,
+    });
   });
 
   test("Deploy a Lambda service handler to Restate Cloud environment", () => {
@@ -56,12 +94,7 @@ describe("Restate constructs", () => {
       apiKey: secrets.Secret.fromSecretNameV2(stack, "CloudApiKey", "secret_name"),
     });
 
-    const handler: lambda.Function = new lambda.Function(stack, "RestateServiceHandler", {
-      runtime: lambda.Runtime.NODEJS_LATEST,
-      handler: "index.handler",
-      code: lambda.Code.fromInline("{ ... }"),
-    });
-
+    const handler = mockHandler(stack);
     const serviceDeployer = new ServiceDeployer(stack, "ServiceDeployer", {
       // only needed in testing, where the relative path of the registration function is different from how customers would use it
       entry: "dist/register-service-handler/index.js",
@@ -181,3 +214,11 @@ describe("Restate constructs", () => {
     });
   });
 });
+
+function mockHandler(stack: cdk.Stack): lambda.Function {
+  return new lambda.Function(stack, "RestateServiceHandler", {
+    runtime: lambda.Runtime.NODEJS_LATEST,
+    handler: "index.handler",
+    code: lambda.Code.fromInline("{ ... }"),
+  });
+}


### PR DESCRIPTION
Inspired by @michael-k's question in #51 about making the environment URL helper functions public.