### PR TITLE
Multiple registration handler bundling improvements

### DIFF
--- a/lib/restate-constructs/register-service-handler/index.ts
+++ b/lib/restate-constructs/register-service-handler/index.ts
@@ -12,7 +12,6 @@
 import { Handler } from "aws-lambda/handler";
 import { CloudFormationCustomResourceEvent } from "aws-lambda/trigger/cloudformation-custom-resource";
 import fetch from "node-fetch";
-import * as cdk from "aws-cdk-lib";
 import { GetSecretValueCommand, SecretsManagerClient } from "@aws-sdk/client-secrets-manager";
 import { randomInt } from "crypto";
 import * as https from "node:https";
@@ -52,7 +51,7 @@ export interface RegistrationProperties {
   /** Whether to trust any certificate when connecting to the admin endpoint. */
   insecure?: "true" | "false";
 
-  removalPolicy?: cdk.RemovalPolicy;
+  // removalPolicy?: string;
 }
 
 type RegisterDeploymentResponse = {

--- a/lib/restate-constructs/service-deployer.ts
+++ b/lib/restate-constructs/service-deployer.ts
@@ -126,6 +126,7 @@ export class ServiceDeployer extends Construct {
       bundling: props?.bundling ?? {
         minify: false,
         sourceMap: true,
+        externalModules: ["@aws-sdk/*", "aws-sdk"],
       },
       ...(props?.vpc
         ? ({
@@ -210,7 +211,7 @@ export class ServiceDeployer extends Construct {
         authTokenSecretArn: authToken?.secretArn,
         serviceLambdaArn: handler.functionArn,
         invokeRoleArn: environment.invokerRole?.roleArn,
-        removalPolicy: cdk.RemovalPolicy.RETAIN,
+        // removalPolicy: "retain",
         private: (options?.private ?? false).toString() as "true" | "false",
         configurationVersion:
           options?.configurationVersion || handler.functionArn.endsWith(":$LATEST")

--- a/lib/restate-constructs/service-deployer.ts
+++ b/lib/restate-constructs/service-deployer.ts
@@ -99,6 +99,7 @@ export class ServiceDeployer extends Construct {
       | "architecture"
       | "runtime"
       | "bundling"
+      | "depsLockFilePath"
       | "code"
       | "entry"
       | "functionName"
@@ -131,6 +132,7 @@ export class ServiceDeployer extends Construct {
         platform: "node",
         target: "node22",
       },
+      depsLockFilePath: props?.depsLockFilePath,
       ...(props?.vpc
         ? ({
             vpc: props?.vpc,

--- a/lib/restate-constructs/service-deployer.ts
+++ b/lib/restate-constructs/service-deployer.ts
@@ -97,6 +97,7 @@ export class ServiceDeployer extends Construct {
       lambda_node.NodejsFunctionProps,
       | "allowPublicSubnet"
       | "architecture"
+      | "runtime"
       | "bundling"
       | "code"
       | "entry"
@@ -117,7 +118,7 @@ export class ServiceDeployer extends Construct {
       description: "Restate custom registration handler",
       entry: props?.entry ?? path.join(__dirname, "register-service-handler/index.js"),
       architecture: props?.architecture ?? lambda.Architecture.ARM_64,
-      runtime: lambda.Runtime.NODEJS_LATEST,
+      runtime: props?.runtime ?? lambda.Runtime.NODEJS_22_X,
       memorySize: 128,
       timeout: props?.timeout ?? DEFAULT_TIMEOUT,
       environment: {
@@ -127,6 +128,8 @@ export class ServiceDeployer extends Construct {
         minify: false,
         sourceMap: true,
         externalModules: ["@aws-sdk/*", "aws-sdk"],
+        platform: "node",
+        target: "node22",
       },
       ...(props?.vpc
         ? ({

--- a/test/__snapshots__/restate-constructs.test.ts.snap
+++ b/test/__snapshots__/restate-constructs.test.ts.snap
@@ -1266,7 +1266,6 @@ exports[`Restate constructs Deploy a Lambda service handler to Restate Cloud env
         'Fn::GetAtt':
           - RestateInvokerRole42565598
           - Arn
-      removalPolicy: retain
       private: 'false'
       insecure: 'false'
     DependsOn:
@@ -1324,7 +1323,7 @@ exports[`Restate constructs Deploy a Lambda service handler to Restate Cloud env
         'Fn::GetAtt':
           - ServiceDeployerEventHandlerServiceRoleF133584F
           - Arn
-      Runtime: nodejs18.x
+      Runtime: nodejs22.x
       Timeout: 180
     DependsOn:
       - ServiceDeployerEventHandlerServiceRoleDefaultPolicyFE2DC3C9
@@ -1524,7 +1523,6 @@ exports[`Restate constructs Deploy a Lambda service handler to existing Restate 
         'Fn::GetAtt':
           - InvokerRole4DB2757E
           - Arn
-      removalPolicy: retain
       private: 'false'
       insecure: 'false'
     DependsOn:
@@ -1578,7 +1576,7 @@ exports[`Restate constructs Deploy a Lambda service handler to existing Restate 
         'Fn::GetAtt':
           - ServiceDeployerEventHandlerServiceRoleF133584F
           - Arn
-      Runtime: nodejs18.x
+      Runtime: nodejs22.x
       Timeout: 180
     DependsOn:
       - ServiceDeployerEventHandlerServiceRoleDefaultPolicyFE2DC3C9
@@ -1882,7 +1880,6 @@ exports[`Restate constructs Restate Cloud Environment construct with role refere
         Ref: >-
           RestateServiceHandlerCurrentVersion40030E671fc2ba09c2d7b4ea8c6a3f8fee895a65
       invokeRoleArn: 'arn:aws:iam::654654156625:role/Invoker'
-      removalPolicy: retain
       private: 'false'
       insecure: 'false'
     DependsOn:
@@ -1940,7 +1937,7 @@ exports[`Restate constructs Restate Cloud Environment construct with role refere
         'Fn::GetAtt':
           - ServiceDeployerEventHandlerServiceRoleF133584F
           - Arn
-      Runtime: nodejs18.x
+      Runtime: nodejs22.x
       Timeout: 180
     DependsOn:
       - ServiceDeployerEventHandlerServiceRoleDefaultPolicyFE2DC3C9
@@ -2069,7 +2066,7 @@ exports[`Restate constructs Service Deployer overrides 1`] = `
         - arm64
       Code:
         S3Bucket: cdk-hnb659fds-assets-account-id-region
-        S3Key: efc7f8d9d681a05675ab384997aaabc138c22aef63a3b0335735af00081d9a9a.zip
+        S3Key: 7c53a580f65616cf4ae29ac9b381d44124f1f8566f9708c0d2226a75abf4355e.zip
       Description: Restate custom registration handler
       Environment:
         Variables:
@@ -2080,7 +2077,7 @@ exports[`Restate constructs Service Deployer overrides 1`] = `
         'Fn::GetAtt':
           - ServiceDeployerEventHandlerServiceRoleF133584F
           - Arn
-      Runtime: nodejs18.x
+      Runtime: nodejs22.x
       Timeout: 180
     DependsOn:
       - ServiceDeployerEventHandlerServiceRoleF133584F


### PR DESCRIPTION
- **Avoid bundling the AWS SDK into the registration handler deployment**
- **Target Node.js 22 explicitly**
- **Expose NodejsFunction's depsLockFilePath property**

Fixes: #54 

This reduces the registration handler bundle size from over 1.7mb by more than half to about 750kb with default settings:

```
❯ tree cdk.out -h
[ 288]  cdk.out
...
├── [  96]  asset.7c53a580f65616cf4ae29ac9b381d44124f1f8566f9708c0d2226a75abf4355e
│   └── [ 97K]  index.js
```

or to under 100kb if minified + source map removed.

cc: @michael-k 