### PR TITLE
Fix wrong env var names in CDK construct

### DIFF
--- a/lib/restate-constructs/single-node-restate-deployment.ts
+++ b/lib/restate-constructs/single-node-restate-deployment.ts
@@ -220,9 +220,9 @@ export class SingleNodeRestateDeployment extends Construct implements IRestateEn
     this.tlsEnabled = props.tlsTermination === TlsTermination.ON_HOST_SELF_SIGNED_CERTIFICATE;
 
     const envDefaults = {
-      RESTATE_OBSERVABILITY__LOG__FORMAT: "Json",
+      RESTATE_LOG_FORMAT: "Json",
       RUST_LOG: "info",
-      RESTATE_OBSERVABILITY__TRACING__ENDPOINT: "http://localhost:4317",
+      RESTATE_TRACING_ENDPOINT: "http://localhost:4317",
     };
     const envArgs = Object.entries({ ...envDefaults, ...(props.environment ?? {}) })
       .map(([key, value]) => `-e ${key}="${value}"`)

--- a/lib/restate-constructs/single-node-restate-deployment.ts
+++ b/lib/restate-constructs/single-node-restate-deployment.ts
@@ -220,7 +220,7 @@ export class SingleNodeRestateDeployment extends Construct implements IRestateEn
     this.tlsEnabled = props.tlsTermination === TlsTermination.ON_HOST_SELF_SIGNED_CERTIFICATE;
 
     const envDefaults = {
-      RESTATE_LOG_FORMAT: "Json",
+      RESTATE_LOG_FORMAT: "json",
       RUST_LOG: "info",
       RESTATE_TRACING_ENDPOINT: "http://localhost:4317",
     };


### PR DESCRIPTION
This PR:

- Fixes default env vars for tracing and log formatting being incorrectly named

This was causing me issues when trying to implement XRay tracing in my CDK code