### PR TITLE
Update default config in EC2 construct for Restate 1.3.0

### DIFF
--- a/test/__snapshots__/restate-constructs.test.ts.snap
+++ b/test/__snapshots__/restate-constructs.test.ts.snap
@@ -657,7 +657,7 @@ exports[`Restate constructs Create a self-hosted Restate environment deployed on
                         set -euf -o pipefail
 
                         yum install -y npm && npm install -gq
-                        @restatedev/restate@latest
+                        @restatedev/restate@latest @restatedev/restatectl@latest
 
                         yum install -y docker
 
@@ -693,44 +693,17 @@ exports[`Restate constructs Create a self-hosted Restate environment deployed on
                         roles = [
                             "worker",
                             "admin",
-                            "metadata-store",
+                            "metadata-server",
+                            "log-server",
                         ]
 
                         node-name = "restate-0"
 
                         cluster-name = "Restate"
 
-                        allow-bootstrap = true
-
-                        bootstrap-num-partitions = 4
-
-                        default-thread-pool-size = 3
-
-                        storage-high-priority-bg-threads = 3
-
-                        storage-low-priority-bg-threads = 3
+                        default-num-partitions = 4
 
                         rocksdb-total-memory-size = "512 MB"
-
-                        rocksdb-total-memtables-ratio = 0.60
-
-                        rocksdb-bg-threads = 3
-
-                        rocksdb-high-priority-bg-threads = 3
-
-
-                        [worker]
-
-                        internal-queue-length = 1000
-
-
-                        [worker.storage]
-
-                        rocksdb-max-background-jobs = 3
-
-                        rocksdb-statistics-level = "except-detailed-timers"
-
-                        num-partitions-to-share-memory-budget = 4
 
 
                         [admin]
@@ -740,27 +713,12 @@ exports[`Restate constructs Create a self-hosted Restate environment deployed on
 
                         [admin.query-engine]
 
-                        memory-size = "50.0 MB"
-
-                        query-parallelism = 4
+                        memory-size = "256.0 MiB"
 
 
                         [ingress]
 
                         bind-address = "127.0.0.1:8080"
-
-                        rocksdb-max-background-jobs = 3
-
-                        rocksdb-statistics-level = "except-detailed-timers"
-
-                        writer-batch-commit-count = 1000
-
-
-                        [metadata-store.rocksdb]
-
-                        rocksdb-max-background-jobs = 1
-
-                        rocksdb-statistics-level = "except-detailed-timers"
 
                         EOF
 
@@ -769,16 +727,16 @@ exports[`Restate constructs Create a self-hosted Restate environment deployed on
                         if [ "$(docker ps -qa -f name=adot)" ]; then docker stop
                         adot || true; docker rm adot; fi
 
-                        docker run --name adot --restart on-failure --detach -p
-                        4317:4317 -p 55680:55680 -p 8889:8888
+                        docker run --name adot --restart on-failure --detach
+                        --pull always -p 4317:4317 -p 55680:55680 -p 8889:8888
                         public.ecr.aws/aws-observability/aws-otel-collector:latest
 
                         if [ "$(docker ps -qa -f name=restate)" ]; then docker
                         stop restate || true; docker rm restate; fi
 
                         docker run --name restate --restart on-failure --detach
-                        --volume /etc/restate:/etc/restate --volume
-                        /var/restate:/restate-data --network=host -e
+                        --pull always --volume /etc/restate:/etc/restate
+                        --volume /var/restate:/restate-data --network=host -e
                         RESTATE_LOG_FORMAT="json" -e RUST_LOG="info" -e
                         RESTATE_TRACING_ENDPOINT="http://localhost:4317"
                         --log-driver=awslogs --log-opt awslogs-group=
@@ -996,6 +954,7 @@ exports[`Restate constructs Create a self-hosted Restate environment deployed on
 
                         yum install -y npm && npm install -gq
                         @restatedev/restate@custom-version
+                        @restatedev/restatectl@custom-version
 
                         yum install -y docker
 
@@ -1031,44 +990,17 @@ exports[`Restate constructs Create a self-hosted Restate environment deployed on
                         roles = [
                             "worker",
                             "admin",
-                            "metadata-store",
+                            "metadata-server",
+                            "log-server",
                         ]
 
                         node-name = "restate-0"
 
                         cluster-name = "Restate"
 
-                        allow-bootstrap = true
-
-                        bootstrap-num-partitions = 4
-
-                        default-thread-pool-size = 3
-
-                        storage-high-priority-bg-threads = 3
-
-                        storage-low-priority-bg-threads = 3
+                        default-num-partitions = 4
 
                         rocksdb-total-memory-size = "512 MB"
-
-                        rocksdb-total-memtables-ratio = 0.60
-
-                        rocksdb-bg-threads = 3
-
-                        rocksdb-high-priority-bg-threads = 3
-
-
-                        [worker]
-
-                        internal-queue-length = 1000
-
-
-                        [worker.storage]
-
-                        rocksdb-max-background-jobs = 3
-
-                        rocksdb-statistics-level = "except-detailed-timers"
-
-                        num-partitions-to-share-memory-budget = 4
 
 
                         [admin]
@@ -1078,27 +1010,12 @@ exports[`Restate constructs Create a self-hosted Restate environment deployed on
 
                         [admin.query-engine]
 
-                        memory-size = "50.0 MB"
-
-                        query-parallelism = 4
+                        memory-size = "256.0 MiB"
 
 
                         [ingress]
 
                         bind-address = "0.0.0.0:8080"
-
-                        rocksdb-max-background-jobs = 3
-
-                        rocksdb-statistics-level = "except-detailed-timers"
-
-                        writer-batch-commit-count = 1000
-
-
-                        [metadata-store.rocksdb]
-
-                        rocksdb-max-background-jobs = 1
-
-                        rocksdb-statistics-level = "except-detailed-timers"
 
                         EOF
 
@@ -1107,16 +1024,16 @@ exports[`Restate constructs Create a self-hosted Restate environment deployed on
                         if [ "$(docker ps -qa -f name=adot)" ]; then docker stop
                         adot || true; docker rm adot; fi
 
-                        docker run --name adot --restart on-failure --detach -p
-                        4317:4317 -p 55680:55680 -p 8889:8888
+                        docker run --name adot --restart on-failure --detach
+                        --pull always -p 4317:4317 -p 55680:55680 -p 8889:8888
                         public.ecr.aws/aws-observability/aws-otel-collector:latest
 
                         if [ "$(docker ps -qa -f name=restate)" ]; then docker
                         stop restate || true; docker rm restate; fi
 
                         docker run --name restate --restart on-failure --detach
-                        --volume /etc/restate:/etc/restate --volume
-                        /var/restate:/restate-data --network=host -e
+                        --pull always --volume /etc/restate:/etc/restate
+                        --volume /var/restate:/restate-data --network=host -e
                         RESTATE_LOG_FORMAT="json" -e RUST_LOG="info" -e
                         RESTATE_TRACING_ENDPOINT="http://localhost:4317" -e
                         RESTATE_INGRESS__ADVERTISED_INGRESS_ENDPOINT="http://restate-ingress"


### PR DESCRIPTION
This change updates the default baseline restate-server config deployed by the EC2 construct to the following:

```toml
roles = [
    "worker",
    "admin",
    "metadata-server",
    "log-server",
]
node-name = "restate-0"
cluster-name = "Restate"
default-num-partitions = 4
rocksdb-total-memory-size = "512 MB"

[admin]
bind-address = "0.0.0.0:9070"

[admin.query-engine]
memory-size = "256.0 MiB"

[ingress]
bind-address = "0.0.0.0:8080"
```

This fixes #72