### PR TITLE
Service deployer tweaks

### DIFF
--- a/lib/restate-constructs/register-service-handler/entrypoint.mts
+++ b/lib/restate-constructs/register-service-handler/entrypoint.mts
@@ -1,4 +1,6 @@
 // from https://github.com/aws/aws-cdk/blob/main/packages/%40aws-cdk/custom-resource-handlers/lib/core/nodejs-entrypoint-handler/index.ts
+// Copyright 2018-2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 import * as https from "https";
 import * as url from "url";

--- a/lib/restate-constructs/register-service-handler/entrypoint.mts
+++ b/lib/restate-constructs/register-service-handler/entrypoint.mts
@@ -1,0 +1,199 @@
+// from https://github.com/aws/aws-cdk/blob/main/packages/%40aws-cdk/custom-resource-handlers/lib/core/nodejs-entrypoint-handler/index.ts
+
+import * as https from "https";
+import * as url from "url";
+
+import { handler as indexHandler } from "./index.mjs";
+
+// for unit tests
+export const external = {
+  sendHttpRequest: defaultSendHttpRequest,
+  log: defaultLog,
+  includeStackTraces: true,
+};
+
+const CREATE_FAILED_PHYSICAL_ID_MARKER = "AWSCDK::CustomResourceProviderFramework::CREATE_FAILED";
+const MISSING_PHYSICAL_ID_MARKER = "AWSCDK::CustomResourceProviderFramework::MISSING_PHYSICAL_ID";
+
+export type Response = AWSLambda.CloudFormationCustomResourceEvent & HandlerResponse;
+export type Handler = (
+  event: AWSLambda.CloudFormationCustomResourceEvent,
+  context: AWSLambda.Context,
+) => Promise<HandlerResponse | void>;
+export type HandlerResponse =
+  | undefined
+  | {
+      Data?: any;
+      PhysicalResourceId?: string;
+      Reason?: string;
+      NoEcho?: boolean;
+    };
+
+export async function handler(event: AWSLambda.CloudFormationCustomResourceEvent, context: AWSLambda.Context) {
+  const sanitizedEvent = { ...event, ResponseURL: "..." };
+  external.log(JSON.stringify(sanitizedEvent, undefined, 2));
+
+  // ignore DELETE event when the physical resource ID is the marker that
+  // indicates that this DELETE is a subsequent DELETE to a failed CREATE
+  // operation.
+  if (event.RequestType === "Delete" && event.PhysicalResourceId === CREATE_FAILED_PHYSICAL_ID_MARKER) {
+    external.log("ignoring DELETE event caused by a failed CREATE event");
+    await submitResponse("SUCCESS", event);
+    return;
+  }
+
+  try {
+    // invoke the user handler. this is intentionally inside the try-catch to
+    // ensure that if there is an error it's reported as a failure to
+    // cloudformation (otherwise cfn waits).
+    const userHandler: Handler = indexHandler;
+    const result = await userHandler(sanitizedEvent, context);
+
+    // validate user response and create the combined event
+    const responseEvent = renderResponse(event, result);
+
+    // submit to cfn as success
+    await submitResponse("SUCCESS", responseEvent);
+  } catch (e: any) {
+    const resp: Response = {
+      ...event,
+      Reason: external.includeStackTraces ? e.stack : e.message,
+    };
+
+    if (!resp.PhysicalResourceId) {
+      // special case: if CREATE fails, which usually implies, we usually don't
+      // have a physical resource id. in this case, the subsequent DELETE
+      // operation does not have any meaning, and will likely fail as well. to
+      // address this, we use a marker so the provider framework can simply
+      // ignore the subsequent DELETE.
+      if (event.RequestType === "Create") {
+        external.log(
+          "CREATE failed, responding with a marker physical resource id so that the subsequent DELETE will be ignored",
+        );
+        resp.PhysicalResourceId = CREATE_FAILED_PHYSICAL_ID_MARKER;
+      } else {
+        // otherwise, if PhysicalResourceId is not specified, something is
+        // terribly wrong because all other events should have an ID.
+        external.log(`ERROR: Malformed event. "PhysicalResourceId" is required: ${JSON.stringify(event)}`);
+      }
+    }
+
+    // this is an actual error, fail the activity altogether and exist.
+    await submitResponse("FAILED", resp);
+  }
+}
+
+function renderResponse(
+  cfnRequest: AWSLambda.CloudFormationCustomResourceEvent & { PhysicalResourceId?: string },
+  handlerResponse: void | HandlerResponse = {},
+): Response {
+  // if physical ID is not returned, we have some defaults for you based
+  // on the request type.
+  const physicalResourceId =
+    handlerResponse.PhysicalResourceId ?? cfnRequest.PhysicalResourceId ?? cfnRequest.RequestId;
+
+  // if we are in DELETE and physical ID was changed, it's an error.
+  if (cfnRequest.RequestType === "Delete" && physicalResourceId !== cfnRequest.PhysicalResourceId) {
+    throw new Error(
+      `DELETE: cannot change the physical resource ID from "${cfnRequest.PhysicalResourceId}" to "${handlerResponse.PhysicalResourceId}" during deletion`,
+    );
+  }
+
+  // merge request event and result event (result prevails).
+  return {
+    ...cfnRequest,
+    ...handlerResponse,
+    PhysicalResourceId: physicalResourceId,
+  };
+}
+
+async function submitResponse(status: "SUCCESS" | "FAILED", event: Response) {
+  const json: AWSLambda.CloudFormationCustomResourceResponse = {
+    Status: status,
+    Reason: event.Reason ?? status,
+    StackId: event.StackId,
+    RequestId: event.RequestId,
+    PhysicalResourceId: event.PhysicalResourceId || MISSING_PHYSICAL_ID_MARKER,
+    LogicalResourceId: event.LogicalResourceId,
+    NoEcho: event.NoEcho,
+    Data: event.Data,
+  };
+
+  const parsedUrl = url.parse(event.ResponseURL);
+  const loggingSafeUrl = `${parsedUrl.protocol}//${parsedUrl.hostname}/${parsedUrl.pathname}?***`;
+  external.log("submit response to cloudformation", loggingSafeUrl, json);
+
+  const responseBody = JSON.stringify(json);
+  const req = {
+    hostname: parsedUrl.hostname,
+    path: parsedUrl.path,
+    method: "PUT",
+    headers: {
+      "content-type": "",
+      "content-length": Buffer.byteLength(responseBody, "utf8"),
+    },
+  };
+
+  const retryOptions = {
+    attempts: 5,
+    sleep: 1000,
+  };
+  await withRetries(retryOptions, external.sendHttpRequest)(req, responseBody);
+}
+
+async function defaultSendHttpRequest(options: https.RequestOptions, requestBody: string): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    try {
+      const request = https.request(options, (response) => {
+        response.resume(); // Consume the response but don't care about it
+        if (!response.statusCode || response.statusCode >= 400) {
+          reject(new Error(`Unsuccessful HTTP response: ${response.statusCode}`));
+        } else {
+          resolve();
+        }
+      });
+      request.on("error", reject);
+      request.write(requestBody);
+      request.end();
+    } catch (e) {
+      reject(e);
+    }
+  });
+}
+
+function defaultLog(fmt: string, ...params: any[]) {
+  // eslint-disable-next-line no-console
+  console.log(fmt, ...params);
+}
+
+export interface RetryOptions {
+  /** How many retries (will at least try once) */
+  readonly attempts: number;
+  /** Sleep base, in ms */
+  readonly sleep: number;
+}
+
+export function withRetries<A extends Array<any>, B>(
+  options: RetryOptions,
+  fn: (...xs: A) => Promise<B>,
+): (...xs: A) => Promise<B> {
+  return async (...xs: A) => {
+    let attempts = options.attempts;
+    let ms = options.sleep;
+    while (true) {
+      try {
+        return await fn(...xs);
+      } catch (e) {
+        if (attempts-- <= 0) {
+          throw e;
+        }
+        await sleep(Math.floor(Math.random() * ms));
+        ms *= 2;
+      }
+    }
+  };
+}
+
+async function sleep(ms: number): Promise<void> {
+  return new Promise((ok) => setTimeout(ok, ms));
+}

--- a/lib/restate-constructs/register-service-handler/index.mts
+++ b/lib/restate-constructs/register-service-handler/index.mts
@@ -72,7 +72,7 @@ const SERVICES_PATH = "services";
  * Custom Resource event handler for Restate service registration. This handler backs the custom resources created by
  * {@link ServiceDeployer} to facilitate Lambda service handler discovery.
  */
-export const handler: Handler<CloudFormationCustomResourceEvent, void> = async function (event) {
+export const handler = async function (event: CloudFormationCustomResourceEvent) {
   console.log({ event });
 
   const props = event.ResourceProperties as RegistrationProperties;

--- a/lib/restate-constructs/register-service-handler/index.mts
+++ b/lib/restate-constructs/register-service-handler/index.mts
@@ -9,11 +9,14 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import { Handler } from "aws-lambda/handler";
-import { CloudFormationCustomResourceEvent } from "aws-lambda/trigger/cloudformation-custom-resource";
-import fetch from "node-fetch";
+import type { Handler } from "aws-lambda/handler";
+import type { CloudFormationCustomResourceEvent } from "aws-lambda/trigger/cloudformation-custom-resource";
+
 import { GetSecretValueCommand, SecretsManagerClient } from "@aws-sdk/client-secrets-manager";
-import { randomInt } from "crypto";
+import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
+import { HttpRequest } from "@aws-sdk/protocol-http";
+
+import { randomInt } from "node:crypto";
 import * as https from "node:https";
 import * as http from "node:http";
 
@@ -74,20 +77,15 @@ export const handler: Handler<CloudFormationCustomResourceEvent, void> = async f
 
   const props = event.ResourceProperties as RegistrationProperties;
 
-  const httpAgent = new http.Agent({
-    keepAlive: true,
+  const httpHandler = new NodeHttpHandler({
+    httpsAgent: new https.Agent({
+      keepAlive: true,
+      rejectUnauthorized: props.insecure !== "true",
+    }),
+    httpAgent: new http.Agent({
+      keepAlive: true,
+    }),
   });
-  const httpsAgent = new https.Agent({
-    keepAlive: true,
-    rejectUnauthorized: props.insecure !== "true",
-  });
-  const agentSelector = (url: URL) => {
-    if (url.protocol == "http:") {
-      return httpAgent;
-    } else {
-      return httpsAgent;
-    }
-  };
 
   if (event.RequestType === "Delete") {
     // Since we retain older Lambda handler versions on update, we also leave the registered service alone. There may
@@ -121,29 +119,35 @@ export const handler: Handler<CloudFormationCustomResourceEvent, void> = async f
 
   let attempt;
 
-  const healthCheckUrl = `${props.adminUrl}/health`;
+  const healthCheckUrl = new URL(`${props.adminUrl}/health`);
 
   attempt = 1;
   console.log(`Performing health check against: ${healthCheckUrl}`);
   while (true) {
     console.log(`Making health check request #${attempt}...`);
-    const controller = new AbortController();
-    const healthCheckTimeout = setTimeout(() => controller.abort("timeout"), 5_000);
     let healthResponse = undefined;
     let errorMessage = undefined;
     try {
-      healthResponse = await fetch(healthCheckUrl, {
-        signal: controller.signal,
-        headers: authHeader,
-        agent: agentSelector,
-      }).finally(() => clearTimeout(healthCheckTimeout));
+      healthResponse = (
+        await httpHandler.handle(
+          new HttpRequest({
+            headers: authHeader,
+            protocol: healthCheckUrl.protocol,
+            hostname: healthCheckUrl.hostname,
+            port: healthCheckUrl.port ? Number(healthCheckUrl.port) : undefined,
+            path: healthCheckUrl.pathname,
+            method: "GET",
+          }),
+          { requestTimeout: 5_000 },
+        )
+      ).response;
 
-      console.log(`Got health check response back: ${healthResponse.status}`);
-      if (healthResponse.status >= 200 && healthResponse.status < 300) {
+      console.log(`Got health check response back: ${healthResponse.statusCode}`);
+      if (healthResponse.statusCode >= 200 && healthResponse.statusCode < 300) {
         break;
       }
       console.error(
-        `Restate health check failed: ${healthResponse.statusText} (${healthResponse.status}; attempt ${attempt})`,
+        `Restate health check failed: ${healthResponse.reason} (${healthResponse.statusCode}; attempt ${attempt})`,
       );
     } catch (e) {
       errorMessage = (e as Error)?.message;
@@ -152,7 +156,7 @@ export const handler: Handler<CloudFormationCustomResourceEvent, void> = async f
 
     if (attempt >= MAX_HEALTH_CHECK_ATTEMPTS) {
       console.error(`Admin service health check failing after ${attempt} attempts.`);
-      throw new Error(errorMessage ?? `${healthResponse?.statusText} (${healthResponse?.status})`);
+      throw new Error(errorMessage ?? `${healthResponse?.reason} (${healthResponse?.statusCode})`);
     }
     attempt += 1;
 
@@ -161,7 +165,7 @@ export const handler: Handler<CloudFormationCustomResourceEvent, void> = async f
     await sleep(waitTimeMillis);
   }
 
-  const deploymentsUrl = `${props.adminUrl}/${DEPLOYMENTS_PATH}`;
+  const deploymentsUrl = new URL(`${props.adminUrl}/${DEPLOYMENTS_PATH}`);
   const registrationRequest = JSON.stringify({
     arn: props.serviceLambdaArn,
     assume_role_arn: props.invokeRoleArn,
@@ -174,21 +178,29 @@ export const handler: Handler<CloudFormationCustomResourceEvent, void> = async f
   registration_retry_loop: while (true) {
     try {
       console.log(`Making registration request #${attempt}...`);
-      const controller = new AbortController();
-      const registerCallTimeout = setTimeout(() => controller.abort("timeout"), 10_000);
-      const registerDeploymentResponse = await fetch(deploymentsUrl, {
-        signal: controller.signal,
-        method: "POST",
-        body: registrationRequest,
-        headers: {
-          "Content-Type": "application/json",
-          ...authHeader,
-        },
-        agent: agentSelector,
-      }).finally(() => clearTimeout(registerCallTimeout));
 
-      if (registerDeploymentResponse.status >= 200 && registerDeploymentResponse.status < 300) {
-        const response = (await registerDeploymentResponse.json()) as RegisterDeploymentResponse;
+      const registerDeploymentResponse = (
+        await httpHandler.handle(
+          new HttpRequest({
+            body: registrationRequest,
+            headers: {
+              "Content-Type": "application/json",
+              ...authHeader,
+            },
+            protocol: deploymentsUrl.protocol,
+            hostname: deploymentsUrl.hostname,
+            port: deploymentsUrl.port ? Number(deploymentsUrl.port) : undefined,
+            path: deploymentsUrl.pathname,
+            method: "POST",
+          }),
+          { requestTimeout: 10_000 },
+        )
+      ).response;
+
+      if (registerDeploymentResponse.statusCode >= 200 && registerDeploymentResponse.statusCode < 300) {
+        const data = await streamCollector(registerDeploymentResponse.body);
+        const dataStr = new TextDecoder().decode(data);
+        const response = JSON.parse(dataStr) as RegisterDeploymentResponse;
 
         if (props.servicePath && !response.services.find((s) => s.name === props.servicePath)) {
           failureReason =
@@ -212,22 +224,29 @@ export const handler: Handler<CloudFormationCustomResourceEvent, void> = async f
           }
 
           console.log(`Marking service ${service.name} as ${isPublic ? "public" : "private"}...`);
-          const controller = new AbortController();
-          const privateCallTimeout = setTimeout(() => controller.abort("timeout"), 10_000);
-          const patchResponse = await fetch(`${props.adminUrl}/${SERVICES_PATH}/${service.name}`, {
-            signal: controller.signal,
-            method: "PATCH",
-            headers: {
-              "Content-Type": "application/json",
-              ...authHeader,
-            },
-            body: JSON.stringify({ public: isPublic }),
-            agent: agentSelector,
-          }).finally(() => clearTimeout(privateCallTimeout));
+          const patchUrl = new URL(`${props.adminUrl}/${SERVICES_PATH}/${service.name}`);
 
-          console.log(`Got patch response back: ${patchResponse.status}`);
-          if (patchResponse.status != 200) {
-            failureReason = `Marking service as ${props.private ? "private" : "public"} failed: ${patchResponse.statusText} (${patchResponse.status})`;
+          const patchResponse = (
+            await httpHandler.handle(
+              new HttpRequest({
+                body: JSON.stringify({ public: isPublic }),
+                headers: {
+                  "Content-Type": "application/json",
+                  ...authHeader,
+                },
+                protocol: patchUrl.protocol,
+                hostname: patchUrl.hostname,
+                port: patchUrl.port ? Number(patchUrl.port) : undefined,
+                path: patchUrl.pathname,
+                method: "PATCH",
+              }),
+              { requestTimeout: 10_000 },
+            )
+          ).response;
+
+          console.log(`Got patch response back: ${patchResponse.statusCode}`);
+          if (patchResponse.statusCode != 200) {
+            failureReason = `Marking service as ${props.private ? "private" : "public"} failed: ${patchResponse.reason} (${patchResponse.statusCode})`;
             break registration_retry_loop; // don't throw immediately - let retry loop decide whether to abort s
           }
 
@@ -236,11 +255,13 @@ export const handler: Handler<CloudFormationCustomResourceEvent, void> = async f
 
         return; // Overall success!
       } else {
-        const errorBody = await registerDeploymentResponse.text();
-        failureReason = `Registration failed (${registerDeploymentResponse.status}): ${errorBody}`;
+        const errorBody = await streamCollector(registerDeploymentResponse.body);
+        const errorBodyStr = new TextDecoder().decode(errorBody);
+
+        failureReason = `Registration failed (${registerDeploymentResponse.reason}): ${errorBodyStr}`;
         console.log({
           message: `Got error response from Restate.`,
-          code: registerDeploymentResponse.status,
+          code: registerDeploymentResponse.statusCode,
           body: errorBody,
         });
       }

--- a/lib/restate-constructs/restate-environment.ts
+++ b/lib/restate-constructs/restate-environment.ts
@@ -11,7 +11,6 @@
 
 import * as iam from "aws-cdk-lib/aws-iam";
 import * as secrets from "aws-cdk-lib/aws-secretsmanager";
-import { FunctionOptions } from "aws-cdk-lib/aws-lambda";
 import { SingleNodeRestateDeployment } from "./single-node-restate-deployment";
 import { RestateCloudEnvironment } from "./restate-cloud-environment";
 
@@ -19,7 +18,7 @@ import { RestateCloudEnvironment } from "./restate-cloud-environment";
  * A Restate environment is a unique deployment of the Restate service. Implementations of this interface may refer to
  * cloud or self-managed environments.
  */
-export interface IRestateEnvironment extends Pick<FunctionOptions, "vpc" | "vpcSubnets" | "securityGroups"> {
+export interface IRestateEnvironment {
   /**
    * The external invoker role that Restate can assume to execute service handlers. If left unset, it's assumed that
    * the Restate deployment has sufficient permissions to invoke the service handlers directly. Setting this role allows

--- a/lib/restate-constructs/service-deployer.ts
+++ b/lib/restate-constructs/service-deployer.ts
@@ -206,7 +206,7 @@ export class ServiceDeployer extends Construct {
 
     const invokerRole = options?.invokerRole ?? environment.invokerRole;
 
-    const deployment = new cdk.CustomResource(handler, "RestateDeployment", {
+    const deployment = new cdk.CustomResource(handler, "RestateServiceDeployment", {
       serviceToken: this.eventHandler.functionArn,
       resourceType: "Custom::RestateServiceDeployment",
       properties: {

--- a/lib/restate-constructs/service-deployer.ts
+++ b/lib/restate-constructs/service-deployer.ts
@@ -12,14 +12,13 @@
 import path from "node:path";
 import { Construct } from "constructs";
 import * as cdk from "aws-cdk-lib";
-import * as cr from "aws-cdk-lib/custom-resources";
 import * as iam from "aws-cdk-lib/aws-iam";
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import * as lambda_node from "aws-cdk-lib/aws-lambda-nodejs";
 import * as logs from "aws-cdk-lib/aws-logs";
 import * as secrets from "aws-cdk-lib/aws-secretsmanager";
 import { IRestateEnvironment } from "./restate-environment";
-import type { RegistrationProperties } from "./register-service-handler/index.mjs";
+import type { RegistrationProperties } from "./register-service-handler/index.mts";
 
 const DEFAULT_TIMEOUT = cdk.Duration.seconds(180);
 
@@ -29,6 +28,13 @@ export interface ServiceRegistrationProps {
    * over the environment's token.
    */
   authToken?: secrets.ISecret;
+
+  /**
+   * The external invoker role that Restate can assume to execute service handlers. If left unset, it's assumed that
+   * the Restate deployment has sufficient permissions to invoke the handler directly. Takes precedence over the
+   * environment's invokerRole.
+   */
+  invokerRole?: iam.IRole;
 
   /**
    * Whether to skip granting the invoker role permission to invoke the service handler. The deployer by default
@@ -81,7 +87,6 @@ export interface ServiceRegistrationProps {
  */
 export class ServiceDeployer extends Construct {
   /** The custom resource provider for handling "deployment" resources. */
-  readonly deploymentResourceProvider: cr.Provider;
   readonly eventHandler: lambda_node.NodejsFunction;
 
   private invocationPolicy?: iam.Policy;
@@ -91,7 +96,8 @@ export class ServiceDeployer extends Construct {
     id: string,
     /**
      * Allows the custom resource event handler properties to be overridden. The main use case for this is specifying
-     * VPC and security group settings for Restate environments that require it.
+     * VPC and security group settings for Restate environments that require it. The event handler must be able
+     * to reach the S3 API, so if the subnet has no egress, it will need an S3 VPC endpoint.
      */
     props?: Partial<
       Pick<
@@ -119,7 +125,7 @@ export class ServiceDeployer extends Construct {
       logGroup: props?.logGroup,
       description: "Restate custom registration handler",
       code: props?.code ?? cdk.aws_lambda.Code.fromAsset(path.join(__dirname, "register-service-handler")),
-      handler: props?.handler ?? "index.handler",
+      handler: props?.handler ?? "entrypoint.handler",
       architecture: props?.architecture ?? lambda.Architecture.ARM_64,
       runtime: props?.runtime ?? lambda.Runtime.NODEJS_22_X,
       role: props?.role,
@@ -146,10 +152,6 @@ export class ServiceDeployer extends Construct {
         removalPolicy: props?.removalPolicy ?? cdk.RemovalPolicy.RETAIN_ON_UPDATE_OR_DELETE,
       });
     }
-
-    this.deploymentResourceProvider = new cr.Provider(this, "CustomResourceProvider", {
-      onEventHandler: this.eventHandler,
-    });
   }
 
   /**
@@ -200,17 +202,19 @@ export class ServiceDeployer extends Construct {
     options?: ServiceRegistrationProps,
   ) {
     const authToken = options?.authToken ?? environment.authToken;
-    authToken?.grantRead(this.deploymentResourceProvider.onEventHandler);
+    authToken?.grantRead(this.eventHandler);
+
+    const invokerRole = options?.invokerRole ?? environment.invokerRole;
 
     const deployment = new cdk.CustomResource(handler, "RestateDeployment", {
-      serviceToken: this.deploymentResourceProvider.serviceToken,
+      serviceToken: this.eventHandler.functionArn,
       resourceType: "Custom::RestateServiceDeployment",
       properties: {
         servicePath: serviceName,
         adminUrl: options?.adminUrl ?? environment.adminUrl,
         authTokenSecretArn: authToken?.secretArn,
         serviceLambdaArn: handler.functionArn,
-        invokeRoleArn: environment.invokerRole?.roleArn,
+        invokeRoleArn: invokerRole?.roleArn,
         // removalPolicy: "retain",
         private: (options?.private ?? false).toString() as "true" | "false",
         configurationVersion:
@@ -221,7 +225,7 @@ export class ServiceDeployer extends Construct {
       } satisfies RegistrationProperties,
     });
 
-    if (environment.invokerRole && !options?.skipInvokeFunctionGrant) {
+    if (invokerRole && !options?.skipInvokeFunctionGrant) {
       // We create a separate policy which we'll attach to the provided invoker role. This breaks a circular cross-stack
       // dependency that would otherwise be created between the service deployer and the invoker role.
       if (!this.invocationPolicy) {
@@ -231,7 +235,7 @@ export class ServiceDeployer extends Construct {
         // defined in the same stack as the service deployer, which seems to help. Some propagation delay might still mean
         // we lean on retries in the deployer event handler in any event but this reduces the probability of failure.
         deployment.node.addDependency(this.invocationPolicy);
-        this.invocationPolicy.attachToRole(environment.invokerRole);
+        this.invocationPolicy.attachToRole(invokerRole);
       }
       this.invocationPolicy.addStatements(
         new iam.PolicyStatement({

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "license": "MIT",
       "devDependencies": {
         "@aws-sdk/client-secrets-manager": "^3.808.0",
+        "@aws-sdk/node-http-handler": "3.374.0",
+        "@aws-sdk/protocol-http": "^3.374.0",
         "@restatedev/restate-sdk": "^1.4.0",
         "@types/aws-lambda": "^8.10.145",
         "@types/jest": "^29.5.14",
@@ -618,6 +620,149 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.374.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.374.0.tgz",
+      "integrity": "sha512-v1Z6m0wwkf65/tKuhwrtPRqVoOtNkDTRn2MBMtxCwEw+8V8Q+YRFqVgGN+J1n53ktE0G5OYVBux/NHiAjJHReQ==",
+      "deprecated": "This package has moved to @smithy/node-http-handler",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-http-handler": "^1.0.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-http-handler/node_modules/@smithy/abort-controller": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-1.1.0.tgz",
+      "integrity": "sha512-5imgGUlZL4dW4YWdMYAKLmal9ny/tlenM81QZY7xYyb76z9Z/QOg7oM5Ak9HQl8QfFTlGVWwcMXl+54jroRgEQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^1.2.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-http-handler/node_modules/@smithy/node-http-handler": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-1.1.0.tgz",
+      "integrity": "sha512-d3kRriEgaIiGXLziAM8bjnaLn1fthCJeTLZIwEIpzQqe6yPX0a+yQoLCTyjb2fvdLwkMoG4p7THIIB5cj5lkbg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^1.1.0",
+        "@smithy/protocol-http": "^1.2.0",
+        "@smithy/querystring-builder": "^1.1.0",
+        "@smithy/types": "^1.2.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-http-handler/node_modules/@smithy/protocol-http": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.2.0.tgz",
+      "integrity": "sha512-GfGfruksi3nXdFok5RhgtOnWe5f6BndzYfmEXISD+5gAGdayFGpjWu5pIqIweTudMtse20bGbc+7MFZXT1Tb8Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^1.2.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-http-handler/node_modules/@smithy/querystring-builder": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-1.1.0.tgz",
+      "integrity": "sha512-gDEi4LxIGLbdfjrjiY45QNbuDmpkwh9DX4xzrR2AzjjXpxwGyfSpbJaYhXARw9p17VH0h9UewnNQXNwaQyYMDA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^1.2.0",
+        "@smithy/util-uri-escape": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-http-handler/node_modules/@smithy/types": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-http-handler/node_modules/@smithy/util-uri-escape": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-1.1.0.tgz",
+      "integrity": "sha512-/jL/V1xdVRt5XppwiaEU8Etp5WHZj609n0xMTuehmCqdoOFbId1M+aEeDWZsQ+8JbEB/BJ6ynY2SlYmOaKtt8w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/protocol-http": {
+      "version": "3.374.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.374.0.tgz",
+      "integrity": "sha512-9WpRUbINdGroV3HiZZIBoJvL2ndoWk39OfwxWs2otxByppJZNN14bg/lvCx5e8ggHUti7IBk5rb0nqQZ4m05pg==",
+      "deprecated": "This package has moved to @smithy/protocol-http",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/protocol-http/node_modules/@smithy/protocol-http": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.2.0.tgz",
+      "integrity": "sha512-GfGfruksi3nXdFok5RhgtOnWe5f6BndzYfmEXISD+5gAGdayFGpjWu5pIqIweTudMtse20bGbc+7MFZXT1Tb8Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^1.2.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/protocol-http/node_modules/@smithy/types": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
     "cdk": "cdk"
   },
   "devDependencies": {
-    "@aws-sdk/client-secrets-manager": "^3.808.0",
+    "@aws-sdk/client-secrets-manager": "^3.374.0",
+    "@aws-sdk/node-http-handler": "3.374.0",
+    "@aws-sdk/protocol-http": "^3.374.0",
     "@restatedev/restate-sdk": "^1.4.0",
     "@types/aws-lambda": "^8.10.145",
     "@types/jest": "^29.5.14",

--- a/test/__snapshots__/restate-constructs.test.ts.snap
+++ b/test/__snapshots__/restate-constructs.test.ts.snap
@@ -1161,7 +1161,7 @@ exports[`Restate constructs Deploy a Lambda service handler to Restate Cloud env
     Properties:
       FunctionName:
         Ref: RestateServiceHandler71409CD7
-  RestateServiceHandlerCurrentVersionRestateDeploymentE8F102EB:
+  RestateServiceHandlerCurrentVersionRestateServiceDeployment1DB3C4D6:
     Type: 'Custom::RestateServiceDeployment'
     Properties:
       ServiceToken:
@@ -1358,7 +1358,7 @@ exports[`Restate constructs Deploy a Lambda service handler to existing Restate 
     Properties:
       FunctionName:
         Ref: RestateServiceHandler71409CD7
-  RestateServiceHandlerCurrentVersionRestateDeploymentE8F102EB:
+  RestateServiceHandlerCurrentVersionRestateServiceDeployment1DB3C4D6:
     Type: 'Custom::RestateServiceDeployment'
     Properties:
       ServiceToken:
@@ -1564,7 +1564,7 @@ exports[`Restate constructs Restate Cloud Environment construct with role refere
     Properties:
       FunctionName:
         Ref: RestateServiceHandler71409CD7
-  RestateServiceHandlerCurrentVersionRestateDeploymentE8F102EB:
+  RestateServiceHandlerCurrentVersionRestateServiceDeployment1DB3C4D6:
     Type: 'Custom::RestateServiceDeployment'
     Properties:
       ServiceToken:
@@ -1704,7 +1704,7 @@ exports[`Restate constructs Service Deployer overrides 1`] = `
         - arm64
       Code:
         S3Bucket: cdk-hnb659fds-assets-account-id-region
-        S3Key: d78ff26eaf1df47242c910dac6a2384d940e8f1968c46c44711fb08af6723ffc.zip
+        S3Key: 5da749bceac78ea316fd0986dcb33aa7b518fc597c8688ad6628223820de4022.zip
       Description: Restate custom registration handler
       Environment:
         Variables:

--- a/test/__snapshots__/restate-constructs.test.ts.snap
+++ b/test/__snapshots__/restate-constructs.test.ts.snap
@@ -1166,7 +1166,7 @@ exports[`Restate constructs Deploy a Lambda service handler to Restate Cloud env
     Properties:
       ServiceToken:
         'Fn::GetAtt':
-          - ServiceDeployerCustomResourceProviderframeworkonEvent528FE6C2
+          - ServiceDeployerEventHandler89EAD25F
           - Arn
       adminUrl: 'https://test.env.us.restate.cloud:9070'
       authTokenSecretArn:
@@ -1233,7 +1233,7 @@ exports[`Restate constructs Deploy a Lambda service handler to Restate Cloud env
       Environment:
         Variables:
           NODE_OPTIONS: '--enable-source-maps'
-      Handler: index.handler
+      Handler: entrypoint.handler
       MemorySize: 128
       Role:
         'Fn::GetAtt':
@@ -1255,76 +1255,6 @@ exports[`Restate constructs Deploy a Lambda service handler to Restate Cloud env
       RetentionInDays: 30
     UpdateReplacePolicy: Retain
     DeletionPolicy: RetainExceptOnCreate
-  ServiceDeployerCustomResourceProviderframeworkonEventServiceRole865AFB0C:
-    Type: 'AWS::IAM::Role'
-    Properties:
-      AssumeRolePolicyDocument:
-        Statement:
-          - Action: 'sts:AssumeRole'
-            Effect: Allow
-            Principal:
-              Service: lambda.amazonaws.com
-        Version: '2012-10-17'
-      ManagedPolicyArns:
-        - 'Fn::Join':
-            - ''
-            - - 'arn:'
-              - Ref: 'AWS::Partition'
-              - ':iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
-  ServiceDeployerCustomResourceProviderframeworkonEventServiceRoleDefaultPolicy740A65C9:
-    Type: 'AWS::IAM::Policy'
-    Properties:
-      PolicyDocument:
-        Statement:
-          - Action: 'lambda:InvokeFunction'
-            Effect: Allow
-            Resource:
-              - 'Fn::GetAtt':
-                  - ServiceDeployerEventHandler89EAD25F
-                  - Arn
-              - 'Fn::Join':
-                  - ''
-                  - - 'Fn::GetAtt':
-                        - ServiceDeployerEventHandler89EAD25F
-                        - Arn
-                    - ':*'
-          - Action: 'lambda:GetFunction'
-            Effect: Allow
-            Resource:
-              'Fn::GetAtt':
-                - ServiceDeployerEventHandler89EAD25F
-                - Arn
-        Version: '2012-10-17'
-      PolicyName: >-
-        ServiceDeployerCustomResourceProviderframeworkonEventServiceRoleDefaultPolicy740A65C9
-      Roles:
-        - Ref: >-
-            ServiceDeployerCustomResourceProviderframeworkonEventServiceRole865AFB0C
-  ServiceDeployerCustomResourceProviderframeworkonEvent528FE6C2:
-    Type: 'AWS::Lambda::Function'
-    Properties:
-      Code: Any<Object>
-      Description: >-
-        AWS CDK resource provider framework - onEvent
-        (RestateCloudStack/ServiceDeployer/CustomResourceProvider)
-      Environment:
-        Variables:
-          USER_ON_EVENT_FUNCTION_ARN:
-            'Fn::GetAtt':
-              - ServiceDeployerEventHandler89EAD25F
-              - Arn
-      Handler: framework.onEvent
-      Role:
-        'Fn::GetAtt':
-          - >-
-            ServiceDeployerCustomResourceProviderframeworkonEventServiceRole865AFB0C
-          - Arn
-      Runtime: nodejs18.x
-      Timeout: 900
-    DependsOn:
-      - >-
-        ServiceDeployerCustomResourceProviderframeworkonEventServiceRoleDefaultPolicy740A65C9
-      - ServiceDeployerCustomResourceProviderframeworkonEventServiceRole865AFB0C
   ServiceDeployerInvocationPolicyD09B639D:
     Type: 'AWS::IAM::Policy'
     Properties:
@@ -1433,7 +1363,7 @@ exports[`Restate constructs Deploy a Lambda service handler to existing Restate 
     Properties:
       ServiceToken:
         'Fn::GetAtt':
-          - ServiceDeployerCustomResourceProviderframeworkonEvent528FE6C2
+          - ServiceDeployerEventHandler89EAD25F
           - Arn
       adminUrl: 'https://restate.example.com:9070'
       authTokenSecretArn:
@@ -1492,7 +1422,7 @@ exports[`Restate constructs Deploy a Lambda service handler to existing Restate 
       Environment:
         Variables:
           NODE_OPTIONS: '--enable-source-maps'
-      Handler: index.handler
+      Handler: entrypoint.handler
       MemorySize: 128
       Role:
         'Fn::GetAtt':
@@ -1514,80 +1444,6 @@ exports[`Restate constructs Deploy a Lambda service handler to existing Restate 
       RetentionInDays: 30
     UpdateReplacePolicy: Retain
     DeletionPolicy: RetainExceptOnCreate
-  ServiceDeployerCustomResourceProviderframeworkonEventServiceRole865AFB0C:
-    Type: 'AWS::IAM::Role'
-    Properties:
-      AssumeRolePolicyDocument:
-        Statement:
-          - Action: 'sts:AssumeRole'
-            Effect: Allow
-            Principal:
-              Service: lambda.amazonaws.com
-        Version: '2012-10-17'
-      ManagedPolicyArns:
-        - 'Fn::Join':
-            - ''
-            - - 'arn:'
-              - Ref: 'AWS::Partition'
-              - ':iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
-  ServiceDeployerCustomResourceProviderframeworkonEventServiceRoleDefaultPolicy740A65C9:
-    Type: 'AWS::IAM::Policy'
-    Properties:
-      PolicyDocument:
-        Statement:
-          - Action: 'lambda:InvokeFunction'
-            Effect: Allow
-            Resource:
-              - 'Fn::GetAtt':
-                  - ServiceDeployerEventHandler89EAD25F
-                  - Arn
-              - 'Fn::Join':
-                  - ''
-                  - - 'Fn::GetAtt':
-                        - ServiceDeployerEventHandler89EAD25F
-                        - Arn
-                    - ':*'
-          - Action: 'lambda:GetFunction'
-            Effect: Allow
-            Resource:
-              'Fn::GetAtt':
-                - ServiceDeployerEventHandler89EAD25F
-                - Arn
-        Version: '2012-10-17'
-      PolicyName: >-
-        ServiceDeployerCustomResourceProviderframeworkonEventServiceRoleDefaultPolicy740A65C9
-      Roles:
-        - Ref: >-
-            ServiceDeployerCustomResourceProviderframeworkonEventServiceRole865AFB0C
-  ServiceDeployerCustomResourceProviderframeworkonEvent528FE6C2:
-    Type: 'AWS::Lambda::Function'
-    Properties:
-      Code: Any<Object>
-      Description: >-
-        AWS CDK resource provider framework - onEvent
-        (LambdaServiceDeployment/ServiceDeployer/CustomResourceProvider)
-      Environment:
-        Variables:
-          USER_ON_EVENT_FUNCTION_ARN:
-            'Fn::GetAtt':
-              - ServiceDeployerEventHandler89EAD25F
-              - Arn
-      Handler: framework.onEvent
-      Role:
-        'Fn::GetAtt':
-          - >-
-            ServiceDeployerCustomResourceProviderframeworkonEventServiceRole865AFB0C
-          - Arn
-      Runtime:
-        'Fn::FindInMap':
-          - LatestNodeRuntimeMap
-          - Ref: 'AWS::Region'
-          - value
-      Timeout: 900
-    DependsOn:
-      - >-
-        ServiceDeployerCustomResourceProviderframeworkonEventServiceRoleDefaultPolicy740A65C9
-      - ServiceDeployerCustomResourceProviderframeworkonEventServiceRole865AFB0C
   ServiceDeployerInvocationPolicyD09B639D:
     Type: 'AWS::IAM::Policy'
     Properties:
@@ -1609,88 +1465,6 @@ exports[`Restate constructs Deploy a Lambda service handler to existing Restate 
       PolicyName: ServiceDeployerInvocationPolicyD09B639D
       Roles:
         - Ref: InvokerRole4DB2757E
-Mappings:
-  LatestNodeRuntimeMap:
-    af-south-1:
-      value: nodejs20.x
-    ap-east-1:
-      value: nodejs20.x
-    ap-northeast-1:
-      value: nodejs20.x
-    ap-northeast-2:
-      value: nodejs20.x
-    ap-northeast-3:
-      value: nodejs20.x
-    ap-south-1:
-      value: nodejs20.x
-    ap-south-2:
-      value: nodejs20.x
-    ap-southeast-1:
-      value: nodejs20.x
-    ap-southeast-2:
-      value: nodejs20.x
-    ap-southeast-3:
-      value: nodejs20.x
-    ap-southeast-4:
-      value: nodejs20.x
-    ap-southeast-5:
-      value: nodejs20.x
-    ap-southeast-7:
-      value: nodejs20.x
-    ca-central-1:
-      value: nodejs20.x
-    ca-west-1:
-      value: nodejs20.x
-    cn-north-1:
-      value: nodejs20.x
-    cn-northwest-1:
-      value: nodejs20.x
-    eu-central-1:
-      value: nodejs20.x
-    eu-central-2:
-      value: nodejs20.x
-    eu-isoe-west-1:
-      value: nodejs18.x
-    eu-north-1:
-      value: nodejs20.x
-    eu-south-1:
-      value: nodejs20.x
-    eu-south-2:
-      value: nodejs20.x
-    eu-west-1:
-      value: nodejs20.x
-    eu-west-2:
-      value: nodejs20.x
-    eu-west-3:
-      value: nodejs20.x
-    il-central-1:
-      value: nodejs20.x
-    me-central-1:
-      value: nodejs20.x
-    me-south-1:
-      value: nodejs20.x
-    mx-central-1:
-      value: nodejs20.x
-    sa-east-1:
-      value: nodejs20.x
-    us-east-1:
-      value: nodejs20.x
-    us-east-2:
-      value: nodejs20.x
-    us-gov-east-1:
-      value: nodejs20.x
-    us-gov-west-1:
-      value: nodejs20.x
-    us-iso-east-1:
-      value: nodejs18.x
-    us-iso-west-1:
-      value: nodejs18.x
-    us-isob-east-1:
-      value: nodejs18.x
-    us-west-1:
-      value: nodejs20.x
-    us-west-2:
-      value: nodejs20.x
 "
 `;
 
@@ -1795,7 +1569,7 @@ exports[`Restate constructs Restate Cloud Environment construct with role refere
     Properties:
       ServiceToken:
         'Fn::GetAtt':
-          - ServiceDeployerCustomResourceProviderframeworkonEvent528FE6C2
+          - ServiceDeployerEventHandler89EAD25F
           - Arn
       adminUrl: 'https://e1.env.eu.restate.cloud:9070'
       authTokenSecretArn:
@@ -1859,7 +1633,7 @@ exports[`Restate constructs Restate Cloud Environment construct with role refere
       Environment:
         Variables:
           NODE_OPTIONS: '--enable-source-maps'
-      Handler: index.handler
+      Handler: entrypoint.handler
       MemorySize: 128
       Role:
         'Fn::GetAtt':
@@ -1881,76 +1655,6 @@ exports[`Restate constructs Restate Cloud Environment construct with role refere
       RetentionInDays: 30
     UpdateReplacePolicy: Retain
     DeletionPolicy: RetainExceptOnCreate
-  ServiceDeployerCustomResourceProviderframeworkonEventServiceRole865AFB0C:
-    Type: 'AWS::IAM::Role'
-    Properties:
-      AssumeRolePolicyDocument:
-        Statement:
-          - Action: 'sts:AssumeRole'
-            Effect: Allow
-            Principal:
-              Service: lambda.amazonaws.com
-        Version: '2012-10-17'
-      ManagedPolicyArns:
-        - 'Fn::Join':
-            - ''
-            - - 'arn:'
-              - Ref: 'AWS::Partition'
-              - ':iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
-  ServiceDeployerCustomResourceProviderframeworkonEventServiceRoleDefaultPolicy740A65C9:
-    Type: 'AWS::IAM::Policy'
-    Properties:
-      PolicyDocument:
-        Statement:
-          - Action: 'lambda:InvokeFunction'
-            Effect: Allow
-            Resource:
-              - 'Fn::GetAtt':
-                  - ServiceDeployerEventHandler89EAD25F
-                  - Arn
-              - 'Fn::Join':
-                  - ''
-                  - - 'Fn::GetAtt':
-                        - ServiceDeployerEventHandler89EAD25F
-                        - Arn
-                    - ':*'
-          - Action: 'lambda:GetFunction'
-            Effect: Allow
-            Resource:
-              'Fn::GetAtt':
-                - ServiceDeployerEventHandler89EAD25F
-                - Arn
-        Version: '2012-10-17'
-      PolicyName: >-
-        ServiceDeployerCustomResourceProviderframeworkonEventServiceRoleDefaultPolicy740A65C9
-      Roles:
-        - Ref: >-
-            ServiceDeployerCustomResourceProviderframeworkonEventServiceRole865AFB0C
-  ServiceDeployerCustomResourceProviderframeworkonEvent528FE6C2:
-    Type: 'AWS::Lambda::Function'
-    Properties:
-      Code: Any<Object>
-      Description: >-
-        AWS CDK resource provider framework - onEvent
-        (RestateCloudStack/ServiceDeployer/CustomResourceProvider)
-      Environment:
-        Variables:
-          USER_ON_EVENT_FUNCTION_ARN:
-            'Fn::GetAtt':
-              - ServiceDeployerEventHandler89EAD25F
-              - Arn
-      Handler: framework.onEvent
-      Role:
-        'Fn::GetAtt':
-          - >-
-            ServiceDeployerCustomResourceProviderframeworkonEventServiceRole865AFB0C
-          - Arn
-      Runtime: nodejs18.x
-      Timeout: 900
-    DependsOn:
-      - >-
-        ServiceDeployerCustomResourceProviderframeworkonEventServiceRoleDefaultPolicy740A65C9
-      - ServiceDeployerCustomResourceProviderframeworkonEventServiceRole865AFB0C
   ServiceDeployerInvocationPolicyD09B639D:
     Type: 'AWS::IAM::Policy'
     Properties:
@@ -2000,12 +1704,12 @@ exports[`Restate constructs Service Deployer overrides 1`] = `
         - arm64
       Code:
         S3Bucket: cdk-hnb659fds-assets-account-id-region
-        S3Key: 09f53e8dd091a6ca655ec479c900de39472a016e69a589263fe84a752615f286.zip
+        S3Key: d78ff26eaf1df47242c910dac6a2384d940e8f1968c46c44711fb08af6723ffc.zip
       Description: Restate custom registration handler
       Environment:
         Variables:
           NODE_OPTIONS: '--enable-source-maps'
-      Handler: index.handler
+      Handler: entrypoint.handler
       MemorySize: 128
       Role:
         'Fn::GetAtt':
@@ -2026,77 +1730,5 @@ exports[`Restate constructs Service Deployer overrides 1`] = `
       RetentionInDays: 30
     UpdateReplacePolicy: Retain
     DeletionPolicy: RetainExceptOnCreate
-  ServiceDeployerCustomResourceProviderframeworkonEventServiceRole865AFB0C:
-    Type: 'AWS::IAM::Role'
-    Properties:
-      AssumeRolePolicyDocument:
-        Statement:
-          - Action: 'sts:AssumeRole'
-            Effect: Allow
-            Principal:
-              Service: lambda.amazonaws.com
-        Version: '2012-10-17'
-      ManagedPolicyArns:
-        - 'Fn::Join':
-            - ''
-            - - 'arn:'
-              - Ref: 'AWS::Partition'
-              - ':iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
-  ServiceDeployerCustomResourceProviderframeworkonEventServiceRoleDefaultPolicy740A65C9:
-    Type: 'AWS::IAM::Policy'
-    Properties:
-      PolicyDocument:
-        Statement:
-          - Action: 'lambda:InvokeFunction'
-            Effect: Allow
-            Resource:
-              - 'Fn::GetAtt':
-                  - ServiceDeployerEventHandler89EAD25F
-                  - Arn
-              - 'Fn::Join':
-                  - ''
-                  - - 'Fn::GetAtt':
-                        - ServiceDeployerEventHandler89EAD25F
-                        - Arn
-                    - ':*'
-          - Action: 'lambda:GetFunction'
-            Effect: Allow
-            Resource:
-              'Fn::GetAtt':
-                - ServiceDeployerEventHandler89EAD25F
-                - Arn
-        Version: '2012-10-17'
-      PolicyName: >-
-        ServiceDeployerCustomResourceProviderframeworkonEventServiceRoleDefaultPolicy740A65C9
-      Roles:
-        - Ref: >-
-            ServiceDeployerCustomResourceProviderframeworkonEventServiceRole865AFB0C
-  ServiceDeployerCustomResourceProviderframeworkonEvent528FE6C2:
-    Type: 'AWS::Lambda::Function'
-    Properties:
-      Code:
-        S3Bucket: cdk-hnb659fds-assets-account-id-region
-        S3Key: bdc104ed9cab1b5b6421713c8155f0b753380595356f710400609664d3635eca.zip
-      Description: >-
-        AWS CDK resource provider framework - onEvent
-        (RestateCloudStack/ServiceDeployer/CustomResourceProvider)
-      Environment:
-        Variables:
-          USER_ON_EVENT_FUNCTION_ARN:
-            'Fn::GetAtt':
-              - ServiceDeployerEventHandler89EAD25F
-              - Arn
-      Handler: framework.onEvent
-      Role:
-        'Fn::GetAtt':
-          - >-
-            ServiceDeployerCustomResourceProviderframeworkonEventServiceRole865AFB0C
-          - Arn
-      Runtime: nodejs18.x
-      Timeout: 900
-    DependsOn:
-      - >-
-        ServiceDeployerCustomResourceProviderframeworkonEventServiceRoleDefaultPolicy740A65C9
-      - ServiceDeployerCustomResourceProviderframeworkonEventServiceRole865AFB0C
 "
 `;

--- a/test/__snapshots__/restate-constructs.test.ts.snap
+++ b/test/__snapshots__/restate-constructs.test.ts.snap
@@ -2000,7 +2000,7 @@ exports[`Restate constructs Service Deployer overrides 1`] = `
         - arm64
       Code:
         S3Bucket: cdk-hnb659fds-assets-account-id-region
-        S3Key: 9b2f401811d992475d0f265d5bf5fdfd2f1fbbe762760b5674e60f80274bc089.zip
+        S3Key: 09f53e8dd091a6ca655ec479c900de39472a016e69a589263fe84a752615f286.zip
       Description: Restate custom registration handler
       Environment:
         Variables:
@@ -2012,7 +2012,7 @@ exports[`Restate constructs Service Deployer overrides 1`] = `
           - ServiceDeployerEventHandlerServiceRoleF133584F
           - Arn
       Runtime: nodejs22.x
-      Timeout: 180
+      Timeout: 123
     DependsOn:
       - ServiceDeployerEventHandlerServiceRoleF133584F
   ServiceDeployerDeploymentLogs5B8BE5D2:

--- a/test/restate-constructs.test.ts
+++ b/test/restate-constructs.test.ts
@@ -83,7 +83,7 @@ describe("Restate constructs", () => {
     const handler = mockHandler(stack);
     const serviceDeployer = new ServiceDeployer(stack, "ServiceDeployer", {
       // only needed in testing, where the relative path of the registration function is different from how customers would use it
-      entry: "dist/register-service-handler/index.js",
+      code: lambda.Code.fromAsset("dist/register-service-handler"),
     });
     serviceDeployer.register(handler.currentVersion, cloudEnvironment);
 
@@ -107,7 +107,7 @@ describe("Restate constructs", () => {
     const handler = mockHandler(stack);
     const serviceDeployer = new ServiceDeployer(stack, "ServiceDeployer", {
       // only needed in testing, where the relative path of the registration function is different from how customers would use it
-      entry: "dist/register-service-handler/index.js",
+      code: lambda.Code.fromAsset("dist/register-service-handler"),
     });
     serviceDeployer.register(handler.currentVersion, cloudEnvironment);
 
@@ -125,12 +125,8 @@ describe("Restate constructs", () => {
 
     new ServiceDeployer(stack, "ServiceDeployer", {
       // only needed in testing, where the relative path of the registration function is different from how customers would use it
-      entry: "dist/register-service-handler/index.js",
-      bundling: {
-        minify: true,
-        sourceMap: false,
-        target: "node20",
-      },
+      code: lambda.Code.fromAsset("dist/register-service-handler"),
+      timeout: cdk.Duration.seconds(123),
     });
 
     expect(stack).toMatchCdkSnapshot({
@@ -164,7 +160,7 @@ describe("Restate constructs", () => {
 
     const serviceDeployer = new ServiceDeployer(stack, "ServiceDeployer", {
       // only needed in testing, where the relative path of the registration function is different from how customers would use it
-      entry: "dist/register-service-handler/index.js",
+      code: lambda.Code.fromAsset("dist/register-service-handler"),
     });
     serviceDeployer.register(handler.currentVersion, restateEnvironment);
 


### PR DESCRIPTION
- Don't use a bundler, just upload mjs files. This required replacing node-fetch which I did with the help of an AWS sdk HTTP lib.
- Allow invoker role to be overriden at register time
- Dont use custom resource framework; we can save a lambda and a role this way.
- Allow role to be specified for the lambda