### PR TITLE
Fix ServiceDeployer LogGroup conflict with useCdkManagedLogGroup feature flag

### DIFF
--- a/lib/restate-constructs/service-deployer.ts
+++ b/lib/restate-constructs/service-deployer.ts
@@ -12,6 +12,7 @@
 import path from "node:path";
 import { Construct } from "constructs";
 import * as cdk from "aws-cdk-lib";
+import * as cx_api from "aws-cdk-lib/cx-api";
 import * as iam from "aws-cdk-lib/aws-iam";
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import * as lambda_node from "aws-cdk-lib/aws-lambda-nodejs";
@@ -219,7 +220,10 @@ export class ServiceDeployer extends Construct {
       allowPublicSubnet: props?.allowPublicSubnet,
     });
 
-    if (!props?.logGroup) {
+    // Skip creating an explicit LogGroup when CDK manages it automatically via the
+    // useCdkManagedLogGroup feature flag - both would resolve to the same name and conflict.
+    const cdkManagedLogGroup = cdk.FeatureFlags.of(this).isEnabled(cx_api.USE_CDK_MANAGED_LAMBDA_LOGGROUP);
+    if (!props?.logGroup && !cdkManagedLogGroup) {
       // By default, Lambda Functions have a log group with never-expiring retention policy.
       new logs.LogGroup(this, "DeploymentLogs", {
         logGroupName: `/aws/lambda/${this.eventHandler.functionName}`,

--- a/test/restate-constructs.test.ts
+++ b/test/restate-constructs.test.ts
@@ -117,6 +117,26 @@ describe("Restate constructs", () => {
     });
   });
 
+  test("ServiceDeployer with useCdkManagedLogGroup feature flag enabled", () => {
+    const app = new cdk.App({
+      context: { "@aws-cdk/aws-lambda:useCdkManagedLogGroup": true },
+    });
+    const stack = new cdk.Stack(app, "RestateCloudStack", {
+      env: { account: "account-id", region: "region" },
+    });
+
+    new ServiceDeployer(stack, "ServiceDeployer", {
+      code: lambda.Code.fromAsset("dist/register-service-handler"),
+    });
+
+    const template = app.synth().getStackByName("RestateCloudStack").template;
+    const logGroups = Object.values(template.Resources as Record<string, { Type: string }>).filter(
+      (r) => r.Type === "AWS::Logs::LogGroup",
+    );
+    // Only the CDK-managed LogGroup created by the Lambda construct; none added by ServiceDeployer
+    expect(logGroups).toHaveLength(1);
+  });
+
   test("Service Deployer overrides", () => {
     const app = new cdk.App();
     const stack = new cdk.Stack(app, "RestateCloudStack", {


### PR DESCRIPTION
## Summary

- Fixes #90
- When `@aws-cdk/aws-lambda:useCdkManagedLogGroup` is enabled (recommended default since CDK 2.200.0), the Lambda construct automatically creates a `AWS::Logs::LogGroup` resource. `ServiceDeployer` was also explicitly creating one with the same name, causing CloudFormation to fail with "already exists in stack".
- Fix: check `cdk.FeatureFlags.of(this).isEnabled(cx_api.USE_CDK_MANAGED_LAMBDA_LOGGROUP)` before creating the explicit log group — skip it when CDK is managing log group creation.

## Test plan

- [x] New unit test: synthesizes `ServiceDeployer` with the feature flag enabled via `App` context, asserts exactly one `AWS::Logs::LogGroup` resource exists (the CDK-managed one from Lambda)
- [x] All existing snapshot tests pass unchanged — no behaviour change when the flag is not set