### PR TITLE
Use corepack to install npm in CI workflows

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -17,7 +17,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
-      - run: npm install -g npm@latest
       - run: npm ci
       - run: npm run lint
       - run: npm run build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,8 +23,10 @@ jobs:
           node-version: "22.x"
           registry-url: "https://registry.npmjs.org"
 
-      # npm 11.5.1+ required for trusted publishing with OIDC
-      - run: npm install -g npm@latest
+      # npm 11.5.1+ required for trusted publishing with OIDC. Use corepack rather than `npm install -g npm@latest`,
+      # which fails on the Node 22 runner image due to a missing dependency in the bundled npm's global-install path.
+      - run: corepack enable
+      - run: corepack install -g npm@latest
       - run: npm ci
 
       # Release: update version BEFORE build so artifacts have correct version


### PR DESCRIPTION
## Summary

The bundled npm in the `actions/setup-node@v4` cached image for Node 22.22.2 fails on the global-install code path with `Cannot find module 'promise-retry'`, which broke `npm install -g npm@latest` in CI. Both pr-checks and publish were affected.

Switch to Corepack, which ships with Node 22 and downloads package managers directly from the registry — sidestepping the broken bundled-npm rebuild path.

## Changes

- **pr-checks.yaml**: Drop the npm upgrade entirely. The bundled npm is fine for `ci`, `build`, and `test` — there's no functional reason to upgrade it for PR checks.
- **publish.yml**: Replace `npm install -g npm@latest` with `corepack enable` + `corepack install -g npm@latest`. OIDC trusted publishing still requires npm 11.5.1+, so we still need a recent npm here, just installed via a different path.

## Test plan

- [x] PR-checks workflow runs cleanly on this PR
- [ ] Snapshot publish to npm succeeds when this is merged to main (publish.yml triggers on push to main)