### PR TITLE
Remove registry-url from setup-node, rely on npm OIDC trusted publishing for auth

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "22.x"
-          registry-url: "https://registry.npmjs.org"
 
       # npm 11.5.1+ required for trusted publishing with OIDC. Use corepack rather than `npm install -g npm@latest`,
       # which fails on the Node 22 runner image due to a missing dependency in the bundled npm's global-install path.


### PR DESCRIPTION
## Summary

- Drops `registry-url` from `actions/setup-node` in the publish workflow
- When `registry-url` is set, setup-node creates a temp `.npmrc` with `_authToken=${NODE_AUTH_TOKEN}`; if that var is set (e.g. to `GITHUB_TOKEN` by the runner), npm uses the token instead of doing an OIDC exchange
- Without `registry-url`, no `.npmrc` with an auth token ref is created; npm falls through to OIDC trusted publishing automatically
- Registry URL is already declared in `package.json` via `publishConfig["@restatedev:registry"]` so nothing is lost
- `NPM_TOKEN` repository secret is no longer needed

## Test plan

- [ ] Merge and observe the next snapshot publish succeeds without `NPM_TOKEN`