### PR TITLE
Fix npm OIDC publish: restore registry-url and clear NODE_AUTH_TOKEN in publish steps

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -82,6 +82,10 @@ jobs:
           npm version ${BASE_VERSION}-SNAPSHOT-$(date '+%Y%m%d%H%M%S') --git-tag-version false
           # We use dist-tag 'dev' for snapshots to avoid users accidentally installing them
           npm publish --provenance --tag dev --access public
+        env:
+          # Clear the GITHUB_TOKEN that setup-node exports as NODE_AUTH_TOKEN; npm must
+          # see no token here so it falls through to OIDC trusted publishing exchange.
+          NODE_AUTH_TOKEN: ""
 
       # Release publish: use 'next' tag for prereleases, 'latest' for stable
       - name: Publish release
@@ -92,3 +96,5 @@ jobs:
           else
             npm publish --provenance --tag latest --access public
           fi
+        env:
+          NODE_AUTH_TOKEN: ""


### PR DESCRIPTION
## Summary

Followup to #95 which went too far.

- Restores `registry-url` in `setup-node` (required: this is what creates the `.npmrc` that enables npm's OIDC token exchange; without it, npm has no auth config at all -> `ENEEDAUTH`)
- `setup-node` with `registry-url` automatically exports `NODE_AUTH_TOKEN=$GITHUB_TOKEN` for subsequent steps; npm sees a non-empty token and uses it instead of OIDC, causing 404
- Fix: explicitly set `NODE_AUTH_TOKEN: ""` in both publish steps so npm sees an empty token and falls through to OIDC trusted publishing exchange

No `NPM_TOKEN` secret needed once this lands.

## Test plan

- [ ] Merge and observe next snapshot publish succeeds via OIDC without `NPM_TOKEN`