### PR TITLE
Pin npm to 10.x for OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,10 +23,10 @@ jobs:
           node-version: "22.x"
           registry-url: "https://registry.npmjs.org"
 
-      # npm 11.5.1+ required for trusted publishing with OIDC. Use corepack rather than `npm install -g npm@latest`,
-      # which fails on the Node 22 runner image due to a missing dependency in the bundled npm's global-install path.
+      # npm 11 breaks OIDC trusted publishing (ENEEDAUTH on empty NODE_AUTH_TOKEN).
+      # Pin to npm 10 via corepack until the regression is fixed upstream.
       - run: corepack enable
-      - run: corepack install -g npm@latest
+      - run: corepack install -g npm@10
       - run: npm ci
 
       # Release: update version BEFORE build so artifacts have correct version


### PR DESCRIPTION
The corepack step is still needed for unrelated reasons, but `npm@latest` (currently 11.14) breaks OIDC trusted publishing — npm 11 returns ENEEDAUTH instead of falling through to OIDC when `_authToken` resolves to empty.

byoc publishes successfully via OIDC using its bundled Node 24 npm (~10.x, judging by the deprecated `always-auth` warnings in its logs). Pinning to npm 10 here matches that working setup.

## Test plan

- [ ] Merge and verify next snapshot publish succeeds without NPM_TOKEN